### PR TITLE
Feat/toggle auto tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ roslaunch axis_camera axis_ptz.launch ip_address:=<camera_ip>
 * `~camera_params` (`robotnik_msgs/Axis`) — Current PTZ state. `focus` and `iris` fields are published as percentage (0–100).
 * `~camera_parameters` (`robotnik_msgs/CameraParameters`) — Zoom range and step configuration.
 * `~joint_states` (`sensor_msgs/JointState`) — Pan, tilt and zoom as joint positions.
+* `~autotracking_active` (`std_msgs/Bool`) — Current auto-tracking state. Latched topic; `true` when auto-tracking is active, `false` otherwise.
 * `~image_settings` (`robotnik_msgs/ImageSettings`) — Current image settings published at `image_settings_pub_rate`. The `is_valid` field indicates whether all fields were successfully read from the camera. On cameras with limited VAPIX read support, last-known values may be used as a fallback (see [Image settings behaviour](#image-settings-behaviour)).
 
 ### Subscribed Topics
@@ -180,6 +181,28 @@ auto: true"
 # Set manual iris to 75%
 rosservice call /axis_camera_ptz/set_iris "value: 75.0
 auto: false"
+```
+
+#### `~set_autotracking` (`robotnik_msgs/SetAutoTracking`)
+Enables or disables auto-tracking on supported camera models.
+
+**Important**: When auto-tracking is active, manual PTZ commands are suppressed by the camera. The node honors this by not sending PTZ commands while `~autotracking_active` is true.
+
+
+Request fields:
+* `enable` (`bool`): if `true`, enable auto-tracking; if `false`, disable it.
+
+Response fields:
+* `success` (`bool`): `true` if the command succeeded; `false` if the camera does not support auto-tracking or a communication error occurred.
+* `message` (`string`): status or error message.
+
+Examples:
+```bash
+# Enable auto-tracking
+rosservice call /axis_camera_ptz/set_autotracking "enable: true"
+
+# Disable auto-tracking
+rosservice call /axis_camera_ptz/set_autotracking "enable: false"
 ```
 
 > **Note on service names**: service names depend on the node namespace. Run `rosservice list` to get the exact names in your setup.

--- a/src/axis_camera/axis_lib/axis_control.py
+++ b/src/axis_camera/axis_lib/axis_control.py
@@ -619,6 +619,39 @@ class ControlAxis():
             conn.close()
         return ret
 
+    def setAutoTracking(self, enable):
+        """
+        Enables or disables auto-tracking via VAPIX.
+        Returns a dict with keys: success (bool), message (str).
+        HTTP 204 => success; HTTP 400 => not supported by this model.
+        """
+        ret = {'success': False, 'message': ''}
+        conn = httplib.HTTPConnection(self.hostname)
+        value = 'on' if enable else 'off'
+        url = '/axis-cgi/com/ptz.cgi?autotrack=%s&camera=1' % value
+        try:
+            conn.request("GET", url)
+            response = conn.getresponse()
+            response.read()  # drain body
+            if response.status == 204:
+                ret['success'] = True
+                ret['message'] = 'Auto-tracking %s' % ('enabled' if enable else 'disabled')
+            elif response.status == 400:
+                ret['success'] = False
+                ret['message'] = 'Auto-tracking not supported by this camera model (HTTP 400)'
+            else:
+                ret['success'] = False
+                ret['message'] = 'Unexpected HTTP status %d while setting auto-tracking' % response.status
+        except socket.error as e:
+            ret['success'] = False
+            ret['message'] = 'Connection error: %s' % str(e)
+        except socket.timeout as e:
+            ret['success'] = False
+            ret['message'] = 'Connection timeout: %s' % str(e)
+        finally:
+            conn.close()
+        return ret
+
     def getPTZState(self):
         """
             Gets the current ptz state/position of the camera

--- a/src/axis_camera/axis_ptz_node.py
+++ b/src/axis_camera/axis_ptz_node.py
@@ -57,6 +57,8 @@ from robotnik_msgs.srv import SetInt16, SetInt16Response
 from robotnik_msgs.srv import SetString, SetStringResponse
 from robotnik_msgs.srv import GetStringList, GetStringListResponse
 from robotnik_msgs.srv import GetImageSettings, GetImageSettingsResponse
+from robotnik_msgs.srv import SetAutoTracking, SetAutoTrackingResponse
+from std_msgs.msg import Bool
 
 class AxisPTZ(threading.Thread):
     """
@@ -132,6 +134,9 @@ class AxisPTZ(threading.Thread):
         self.iris_min_value = 1.0
         self.iris_max_value = 9999.0
         self.iris_two_step_control = args.get('iris_two_step_control', False)
+
+        # Auto-tracking state
+        self.autotracking_active = False
 
         # Detect effective focus range at runtime
         self.effective_focus_min_raw = None
@@ -282,6 +287,8 @@ class AxisPTZ(threading.Thread):
         self.set_white_balance_service = rospy.Service('~set_white_balance', SetString, self.setWhiteBalanceServiceCb)
         self.get_white_balance_mode_service = rospy.Service('~get_white_balance_mode', GetStringList, self.getWhiteBalanceModeServiceCb)
         self.get_image_settings_service = rospy.Service('~get_image_settings', GetImageSettings, self.getImageSettingsServiceCb)
+        self.autotracking_pub = rospy.Publisher('~autotracking_active', Bool, queue_size=10, latch=True)
+        self.set_autotracking_service = rospy.Service('~set_autotracking', SetAutoTracking, self.setAutoTrackingServiceCb)
         self.loadDeviceInfo()
         self.device_info_service = rospy.Service('~get_device_info', GetAxisDeviceInfo, self.getDeviceInfoServiceCb)
 
@@ -324,11 +331,28 @@ class AxisPTZ(threading.Thread):
             firmware=self.device_firmware
         )
 
+    def setAutoTrackingServiceCb(self, req):
+        response = SetAutoTrackingResponse()
+        result = self.controller.setAutoTracking(req.enable)
+        response.success = result['success']
+        response.message = result['message']
+        if result['success']:
+            self.autotracking_active = req.enable
+            self.autotracking_pub.publish(Bool(data=self.autotracking_active))
+            rospy.loginfo('%s:setAutoTrackingServiceCb: %s', rospy.get_name(), result['message'])
+        else:
+            rospy.logerr('%s:setAutoTrackingServiceCb: %s', rospy.get_name(), result['message'])
+        return response
+
     def commandPTZCb(self, msg):
         """
             Command for ptz movements
         """
         self.t_last_command_time = rospy.Time.now()
+
+        if self.autotracking_active:
+            rospy.logwarn_throttle(5, '%s:commandPTZCb: ignoring PTZ command, auto-tracking is active', rospy.get_name())
+            return
 
         if self.ptz_syncronized:
             self.setCommandPTZ(msg)
@@ -658,6 +682,9 @@ class AxisPTZ(threading.Thread):
         """
         t_now = rospy.Time.now()
 
+        if self.autotracking_active:
+            return
+
         if self.control_mode == 'position':
             # Only if it's syncronized
             if self.ptz_syncronized:
@@ -838,6 +865,8 @@ class AxisPTZ(threading.Thread):
         zoom_parameters.zoom_augments = self.zoom_augments
 
         self.zoom_parameter_pub.publish(zoom_parameters)
+        # Publishes the auto-tracking state
+        self.autotracking_pub.publish(Bool(data=self.autotracking_active))
         # Publishes the current PTZ values
         self.pub.publish(self.current_ptz)
         


### PR DESCRIPTION
## Feat/toggle auto tracking
feat: add auto-tracking control service and state publishing for Axis PTZ

### Summary
Add ROS support to enable/disable Axis auto-tracking and publish its state.
When auto-tracking is active, manual PTZ commands are suppressed to avoid interference.

### What Changed
SetAutoTracking.srv
CMakeLists.txt
axis_control.py
axis_ptz_node.py
README.md

### For testing
**Enable auto-tracking**
```
rosservice call /axis_camera_ptz/set_autotracking "enable: true"
```
**Disable auto-tracking**
```
rosservice call /axis_camera_ptz/set_autotracking "enable: false"
```
**Check state topic**
```
rostopic echo -n 1 /axis_camera_ptz/autotracking_active
```
