### PR TITLE
Feat/toggle auto tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ roslaunch axis_camera axis_ptz.launch ip_address:=<camera_ip>
 * `~camera_params` (`robotnik_msgs/Axis`) — Current PTZ state. `focus` and `iris` fields are published as percentage (0–100).
 * `~camera_parameters` (`robotnik_msgs/CameraParameters`) — Zoom range and step configuration.
 * `~joint_states` (`sensor_msgs/JointState`) — Pan, tilt and zoom as joint positions.
+* `~autotracking_active` (`std_msgs/Bool`) — Current auto-tracking state. Latched topic; `true` when auto-tracking is active, `false` otherwise.
 * `~image_settings` (`robotnik_msgs/ImageSettings`) — Current image settings published at `image_settings_pub_rate`. The `is_valid` field indicates whether all fields were successfully read from the camera. On cameras with limited VAPIX read support, last-known values may be used as a fallback (see [Image settings behaviour](#image-settings-behaviour)).
 
 ### Subscribed Topics
@@ -180,6 +181,28 @@ auto: true"
 # Set manual iris to 75%
 rosservice call /axis_camera_ptz/set_iris "value: 75.0
 auto: false"
+```
+
+#### `~set_autotracking` (`robotnik_msgs/SetAutoTracking`)
+Enables or disables auto-tracking on supported camera models.
+
+**Important**: When auto-tracking is active, manual PTZ commands are suppressed by the camera. The node honors this by not sending PTZ commands while `~autotracking_active` is true.
+
+
+Request fields:
+* `enable` (`bool`): if `true`, enable auto-tracking; if `false`, disable it.
+
+Response fields:
+* `success` (`bool`): `true` if the command succeeded; `false` if the camera does not support auto-tracking or a communication error occurred.
+* `message` (`string`): status or error message.
+
+Examples:
+```bash
+# Enable auto-tracking
+rosservice call /axis_camera_ptz/set_autotracking "enable: true"
+
+# Disable auto-tracking
+rosservice call /axis_camera_ptz/set_autotracking "enable: false"
 ```
 
 > **Note on service names**: service names depend on the node namespace. Run `rosservice list` to get the exact names in your setup.

--- a/README.md
+++ b/README.md
@@ -274,6 +274,15 @@ relative: false"
 * `zoom` as float (proportional value between `min_zoom_augment` and `max_zoom_augment`)
 * `relative` as bool — if `true`, values are added to the current position
 
+### Auto-tracking behaviour
+
+* Auto-tracking is controlled via two endpoints tried in order:
+  1. **VAPIX PTZ Autotracking API** (`/axis-cgi/ptz-autotracking/operator.cgi`) — official endpoint available on cameras with firmware ≥ 10.x.
+  2. **PTZ Autotracker ACAP app** (`/local/axis-ptz-autotracking/settings.fcgi`) — the app's own REST API, used by the camera web UI. Available on any camera with the PTZ Autotracker ACAP app installed.
+* If neither endpoint responds, `success=false` is returned with a descriptive message (e.g. app not installed).
+* While auto-tracking is active, the node suppresses all outgoing PTZ commands (both topic-based commands and the continuous control loop).
+* The node polls the camera every 2 seconds to detect state changes made outside ROS (e.g. via the camera web UI or VMS). The `~autotracking_active` topic is updated automatically if a change is detected.
+
 ### Focus and iris behaviour
 
 * Focus and iris limits are **read from the camera at startup** and used to map between raw camera units and percentage.

--- a/src/axis_camera/axis_lib/axis_control.py
+++ b/src/axis_camera/axis_lib/axis_control.py
@@ -619,6 +619,39 @@ class ControlAxis():
             conn.close()
         return ret
 
+    def setAutoTracking(self, enable):
+        """
+        Enables or disables auto-tracking via VAPIX.
+        Returns a dict with keys: success (bool), message (str).
+        HTTP 204 => success; HTTP 400 => not supported by this model.
+        """
+        ret = {'success': False, 'message': ''}
+        conn = httplib.HTTPConnection(self.hostname)
+        value = 'on' if enable else 'off'
+        url = '/axis-cgi/com/ptz.cgi?autotrack=%s&camera=1' % value
+        try:
+            conn.request("GET", url)
+            response = conn.getresponse()
+            response.read()  # drain body
+            if response.status == 204:
+                ret['success'] = True
+                ret['message'] = 'Auto-tracking %s' % ('enabled' if enable else 'disabled')
+            elif response.status == 400:
+                ret['success'] = False
+                ret['message'] = 'Auto-tracking not supported by this camera model (HTTP 400)'
+            else:
+                ret['success'] = False
+                ret['message'] = 'Unexpected HTTP status %d while setting auto-tracking' % response.status
+        except socket.error as e:
+            ret['success'] = False
+            ret['message'] = 'Connection error: %s' % str(e)
+        except socket.timeout as e:
+            ret['success'] = False
+            ret['message'] = 'Connection timeout: %s' % str(e)
+        finally:
+            conn.close()
+        return ret
+
     def getPTZState(self):
         """
             Gets the current ptz state/position of the camera

--- a/src/axis_camera/axis_lib/axis_control.py
+++ b/src/axis_camera/axis_lib/axis_control.py
@@ -18,6 +18,7 @@ except:
 import socket
 import math
 import xml.etree.ElementTree as ET
+import json
 
 class ControlAxis():
     def __init__(self, hostname, username='root', password=''):
@@ -619,38 +620,220 @@ class ControlAxis():
             conn.close()
         return ret
 
+    def _try_autotracking_vapix(self, opener, enable):
+        """
+        Tries to set autotracking via official VAPIX PTZ Autotracking API.
+        Available on cameras with firmware >= 10.x that expose the CGI natively.
+        Returns (success, message) tuple. success=None means 404 => try fallback.
+        """
+        url = 'http://%s/axis-cgi/ptz-autotracking/operator.cgi' % self.hostname
+        payload = {
+            'apiVersion': '1.0',
+            'method': 'setAutotrackingState',
+            'params': {'enabled': bool(enable)}
+        }
+        try:
+            request = urllib_request.Request(
+                url,
+                data=json.dumps(payload).encode('utf-8'),
+                headers={'Content-Type': 'application/json'}
+            )
+            response = opener.open(request, timeout=5)
+            body = response.read().decode('utf-8', errors='replace').strip()
+            if response.getcode() in (200, 204):
+                if body:
+                    try:
+                        body_json = json.loads(body)
+                    except Exception:
+                        body_json = None
+                    if isinstance(body_json, dict) and isinstance(body_json.get('error'), dict):
+                        return False, 'VAPIX operator.cgi error: %s' % str(body_json['error'].get('code'))
+                return True, 'Auto-tracking %s via VAPIX operator.cgi' % ('enabled' if enable else 'disabled')
+            return False, 'VAPIX operator.cgi HTTP %d' % response.getcode()
+        except urllib_error.HTTPError as e:
+            if e.code == 404:
+                return None, 'VAPIX operator.cgi not found (404)'  # None = try fallback
+            return False, 'VAPIX operator.cgi HTTP error %d: %s' % (e.code, e.reason)
+        except (urllib_error.URLError, socket.timeout) as e:
+            return False, 'VAPIX operator.cgi connection error: %s' % str(e)
+
+    def _try_autotracking_acap(self, opener, enable):
+        """
+        Tries to set autotracking via the PTZ Autotracker ACAP app local endpoint.
+        This is the API the app exposes regardless of firmware version, and is the
+        same endpoint used by the camera web UI. Works on cameras like P5676-LE.
+        Returns (success, message) tuple.
+        """
+        url = 'http://%s/local/axis-ptz-autotracking/settings.fcgi' % self.hostname
+        payload = {
+            'apiVersion': '1.0',
+            'method': 'setAutotrackingState',
+            'params': {'enabled': bool(enable)}
+        }
+        try:
+            request = urllib_request.Request(
+                url,
+                data=json.dumps(payload).encode('utf-8'),
+                headers={'Content-Type': 'application/json'}
+            )
+            response = opener.open(request, timeout=5)
+            body = response.read().decode('utf-8', errors='replace').strip()
+            if response.getcode() in (200, 204):
+                if body:
+                    try:
+                        body_json = json.loads(body)
+                    except Exception:
+                        body_json = None
+                    if isinstance(body_json, dict) and isinstance(body_json.get('error'), dict):
+                        return False, 'ACAP settings.fcgi error: %s' % str(body_json['error'].get('code'))
+                return True, 'Auto-tracking %s via ACAP settings.fcgi' % ('enabled' if enable else 'disabled')
+            return False, 'ACAP settings.fcgi HTTP %d' % response.getcode()
+        except urllib_error.HTTPError as e:
+            if e.code == 404:
+                return False, 'ACAP settings.fcgi not found (404) - PTZ Autotracker app may not be installed'
+            return False, 'ACAP settings.fcgi HTTP error %d: %s' % (e.code, e.reason)
+        except (urllib_error.URLError, socket.timeout) as e:
+            return False, 'ACAP settings.fcgi connection error: %s' % str(e)
+
     def setAutoTracking(self, enable):
         """
-        Enables or disables auto-tracking via VAPIX.
+        Enables or disables auto-tracking on Axis PTZ cameras.
+
+        Uses a two-tier approach to support a wide range of camera models:
+          1. VAPIX PTZ Autotracking API (/axis-cgi/ptz-autotracking/operator.cgi)
+             - Official Axis API, available on cameras with firmware >= 10.x
+          2. PTZ Autotracker ACAP app local API (/local/axis-ptz-autotracking/settings.fcgi)
+             - The app's own REST endpoint, used by the web UI, available on any
+               camera with the PTZ Autotracker ACAP app installed (e.g. P5676-LE)
+
         Returns a dict with keys: success (bool), message (str).
-        HTTP 204 => success; HTTP 400 => not supported by this model.
         """
         ret = {'success': False, 'message': ''}
-        conn = httplib.HTTPConnection(self.hostname)
-        value = 'on' if enable else 'off'
-        url = '/axis-cgi/com/ptz.cgi?autotrack=%s&camera=1' % value
-        try:
-            conn.request("GET", url)
-            response = conn.getresponse()
-            response.read()  # drain body
-            if response.status == 204:
-                ret['success'] = True
-                ret['message'] = 'Auto-tracking %s' % ('enabled' if enable else 'disabled')
-            elif response.status == 400:
-                ret['success'] = False
-                ret['message'] = 'Auto-tracking not supported by this camera model (HTTP 400)'
-            else:
-                ret['success'] = False
-                ret['message'] = 'Unexpected HTTP status %d while setting auto-tracking' % response.status
-        except socket.error as e:
-            ret['success'] = False
-            ret['message'] = 'Connection error: %s' % str(e)
-        except socket.timeout as e:
-            ret['success'] = False
-            ret['message'] = 'Connection timeout: %s' % str(e)
-        finally:
-            conn.close()
+        opener = self._get_digest_opener()
+
+        # 1. Try official VAPIX endpoint first
+        success, message = self._try_autotracking_vapix(opener, enable)
+        if success is True:
+            ret['success'] = True
+            ret['message'] = message
+            return ret
+        if success is False:
+            ret['message'] = message
+            return ret
+
+        # success is None => 404, fall through to ACAP app endpoint
+        # 2. Fall back to ACAP app local endpoint
+        success, message = self._try_autotracking_acap(opener, enable)
+        ret['success'] = success
+        ret['message'] = message
         return ret
+
+    def _extract_autotracking_enabled(self, payload):
+        """
+        Extracts autotracking enabled state from different JSON response shapes.
+        Returns True/False when found, otherwise None.
+        """
+        if isinstance(payload, bool):
+            return payload
+
+        if not isinstance(payload, dict):
+            return None
+
+        # Fast path for common direct keys
+        for key in ('enabled', 'active', 'autotracking', 'autotrack'):
+            value = payload.get(key)
+            if isinstance(value, bool):
+                return value
+
+        # Recursive walk for nested structures (data/result/params/etc.)
+        stack = [payload]
+        while stack:
+            current = stack.pop()
+            if not isinstance(current, dict):
+                continue
+
+            for key, value in current.items():
+                if key in ('enabled', 'active', 'autotracking', 'autotrack'):
+                    if isinstance(value, bool):
+                        return value
+                    if isinstance(value, str):
+                        lowered = value.strip().lower()
+                        if lowered in ('1', 'true', 'on', 'enabled', 'yes'):
+                            return True
+                        if lowered in ('0', 'false', 'off', 'disabled', 'no'):
+                            return False
+                if isinstance(value, dict):
+                    stack.append(value)
+
+        return None
+
+    def _read_autotracking_state_endpoint(self, opener, url):
+        """
+        Reads autotracking state from one endpoint trying common getter methods.
+        Returns (success, enabled, message).
+        """
+        methods = ('getAutotrackingState', 'getAutotrackerState', 'getState')
+        for method in methods:
+            payload = {
+                'apiVersion': '1.0',
+                'method': method,
+                'params': {}
+            }
+            try:
+                request = urllib_request.Request(
+                    url,
+                    data=json.dumps(payload).encode('utf-8'),
+                    headers={'Content-Type': 'application/json'}
+                )
+                response = opener.open(request, timeout=5)
+                body = response.read().decode('utf-8', errors='replace').strip()
+                if response.getcode() not in (200, 204):
+                    continue
+                if not body:
+                    continue
+
+                try:
+                    body_json = json.loads(body)
+                except Exception:
+                    continue
+
+                if isinstance(body_json, dict) and isinstance(body_json.get('error'), dict):
+                    continue
+
+                enabled = self._extract_autotracking_enabled(body_json)
+                if enabled is not None:
+                    return True, enabled, 'read via %s' % url
+            except urllib_error.HTTPError as e:
+                if e.code == 404:
+                    return False, None, '%s not found (404)' % url
+            except (urllib_error.URLError, socket.timeout) as e:
+                return False, None, 'connection error on %s: %s' % (url, str(e))
+
+        return False, None, 'no readable state on %s' % url
+
+    def getAutoTrackingState(self):
+        """
+        Reads current autotracking state from camera APIs.
+        Returns a dict: success (bool), enabled (bool or None), message (str).
+        """
+        opener = self._get_digest_opener()
+        urls = (
+            'http://%s/axis-cgi/ptz-autotracking/operator.cgi' % self.hostname,
+            'http://%s/local/axis-ptz-autotracking/settings.fcgi' % self.hostname,
+        )
+
+        errors = []
+        for url in urls:
+            success, enabled, message = self._read_autotracking_state_endpoint(opener, url)
+            if success:
+                return {'success': True, 'enabled': enabled, 'message': message}
+            errors.append(message)
+
+        return {
+            'success': False,
+            'enabled': None,
+            'message': '; '.join(errors)
+        }
 
     def getPTZState(self):
         """

--- a/src/axis_camera/axis_lib/axis_control.py
+++ b/src/axis_camera/axis_lib/axis_control.py
@@ -620,6 +620,42 @@ class ControlAxis():
             conn.close()
         return ret
 
+    def _try_autotracking_admin(self, opener, enable):
+        """
+        Tries to set autotracking via VAPIX PTZ Autotracking admin API.
+        Returns (success, message) tuple. success=None means 404 => try fallback.
+        """
+        url = 'http://%s/axis-cgi/ptz-autotracking/admin.cgi' % self.hostname
+        payload = {
+            'apiVersion': '1.0',
+            'method': 'setAutotrackingState',
+            'params': {'enabled': bool(enable)}
+        }
+        try:
+            request = urllib_request.Request(
+                url,
+                data=json.dumps(payload).encode('utf-8'),
+                headers={'Content-Type': 'application/json', 'Accept': 'application/json'}
+            )
+            response = opener.open(request, timeout=5)
+            body = response.read().decode('utf-8', errors='replace').strip()
+            if response.getcode() in (200, 204):
+                if body:
+                    try:
+                        body_json = json.loads(body)
+                    except Exception:
+                        body_json = None
+                    if isinstance(body_json, dict) and isinstance(body_json.get('error'), dict):
+                        return False, 'VAPIX admin.cgi error: %s' % str(body_json['error'].get('code'))
+                return True, 'Auto-tracking %s via VAPIX admin.cgi' % ('enabled' if enable else 'disabled')
+            return False, 'VAPIX admin.cgi HTTP %d' % response.getcode()
+        except urllib_error.HTTPError as e:
+            if e.code == 404:
+                return None, 'VAPIX admin.cgi not found (404)'
+            return False, 'VAPIX admin.cgi HTTP error %d: %s' % (e.code, e.reason)
+        except (urllib_error.URLError, socket.timeout) as e:
+            return False, 'VAPIX admin.cgi connection error: %s' % str(e)
+
     def _try_autotracking_vapix(self, opener, enable):
         """
         Tries to set autotracking via official VAPIX PTZ Autotracking API.
@@ -699,10 +735,12 @@ class ControlAxis():
         """
         Enables or disables auto-tracking on Axis PTZ cameras.
 
-        Uses a two-tier approach to support a wide range of camera models:
-          1. VAPIX PTZ Autotracking API (/axis-cgi/ptz-autotracking/operator.cgi)
-             - Official Axis API, available on cameras with firmware >= 10.x
-          2. PTZ Autotracker ACAP app local API (/local/axis-ptz-autotracking/settings.fcgi)
+          Uses a three-tier approach to support a wide range of camera models:
+             1. VAPIX PTZ Autotracking admin API (/axis-cgi/ptz-autotracking/admin.cgi)
+                 - Newer firmware endpoint.
+             2. VAPIX PTZ Autotracking operator API (/axis-cgi/ptz-autotracking/operator.cgi)
+                 - Older firmware endpoint.
+             3. PTZ Autotracker ACAP app local API (/local/axis-ptz-autotracking/settings.fcgi)
              - The app's own REST endpoint, used by the web UI, available on any
                camera with the PTZ Autotracker ACAP app installed (e.g. P5676-LE)
 
@@ -711,7 +749,17 @@ class ControlAxis():
         ret = {'success': False, 'message': ''}
         opener = self._get_digest_opener()
 
-        # 1. Try official VAPIX endpoint first
+        # 1. Try VAPIX admin endpoint first
+        success, message = self._try_autotracking_admin(opener, enable)
+        if success is True:
+            ret['success'] = True
+            ret['message'] = message
+            return ret
+        if success is False:
+            ret['message'] = message
+            return ret
+
+        # 2. Try legacy VAPIX operator endpoint
         success, message = self._try_autotracking_vapix(opener, enable)
         if success is True:
             ret['success'] = True
@@ -722,7 +770,7 @@ class ControlAxis():
             return ret
 
         # success is None => 404, fall through to ACAP app endpoint
-        # 2. Fall back to ACAP app local endpoint
+        # 3. Fall back to ACAP app local endpoint
         success, message = self._try_autotracking_acap(opener, enable)
         ret['success'] = success
         ret['message'] = message
@@ -818,6 +866,7 @@ class ControlAxis():
         """
         opener = self._get_digest_opener()
         urls = (
+            'http://%s/axis-cgi/ptz-autotracking/admin.cgi' % self.hostname,
             'http://%s/axis-cgi/ptz-autotracking/operator.cgi' % self.hostname,
             'http://%s/local/axis-ptz-autotracking/settings.fcgi' % self.hostname,
         )

--- a/src/axis_camera/axis_ptz_node.py
+++ b/src/axis_camera/axis_ptz_node.py
@@ -288,6 +288,7 @@ class AxisPTZ(threading.Thread):
         self.get_white_balance_mode_service = rospy.Service('~get_white_balance_mode', GetStringList, self.getWhiteBalanceModeServiceCb)
         self.get_image_settings_service = rospy.Service('~get_image_settings', GetImageSettings, self.getImageSettingsServiceCb)
         self.autotracking_pub = rospy.Publisher('~autotracking_active', Bool, queue_size=10, latch=True)
+        self.autotracking_pub.publish(Bool(data=self.autotracking_active))
         self.set_autotracking_service = rospy.Service('~set_autotracking', SetAutoTracking, self.setAutoTrackingServiceCb)
         self.loadDeviceInfo()
         self.device_info_service = rospy.Service('~get_device_info', GetAxisDeviceInfo, self.getDeviceInfoServiceCb)
@@ -298,6 +299,8 @@ class AxisPTZ(threading.Thread):
         self.diagnostics_updater.add("Ptz state updater", self.getStateDiagnostic)
         # Creates a periodic callback to publish the diagnostics at desired freq
         self.diagnostics_timer = rospy.Timer(rospy.Duration(1.0), self.publishDiagnostics)
+        # Poll autotracking state to detect changes made outside ROS (web UI, VMS, etc.)
+        self.autotracking_poll_timer = rospy.Timer(rospy.Duration(2.0), self.pollAutoTrackingState)
 
         self.zoom_augments = []
         for i in range(int(self.min_zoom_augment), int(self.max_zoom_augment) + 1, int(self.min_zoom_step)):
@@ -343,6 +346,22 @@ class AxisPTZ(threading.Thread):
         else:
             rospy.logerr('%s:setAutoTrackingServiceCb: %s', rospy.get_name(), result['message'])
         return response
+
+    def pollAutoTrackingState(self, event):
+        """
+        Synchronizes autotracking state with camera in case it is changed externally.
+        """
+        result = self.controller.getAutoTrackingState()
+        if not result['success']:
+            rospy.logdebug_throttle(30, '%s:pollAutoTrackingState: %s', rospy.get_name(), result['message'])
+            return
+
+        camera_state = bool(result['enabled'])
+        if camera_state != self.autotracking_active:
+            self.autotracking_active = camera_state
+            self.autotracking_pub.publish(Bool(data=self.autotracking_active))
+            rospy.loginfo('%s:pollAutoTrackingState: autotracking updated from camera: %s',
+                          rospy.get_name(), self.autotracking_active)
 
     def commandPTZCb(self, msg):
         """
@@ -865,8 +884,6 @@ class AxisPTZ(threading.Thread):
         zoom_parameters.zoom_augments = self.zoom_augments
 
         self.zoom_parameter_pub.publish(zoom_parameters)
-        # Publishes the auto-tracking state
-        self.autotracking_pub.publish(Bool(data=self.autotracking_active))
         # Publishes the current PTZ values
         self.pub.publish(self.current_ptz)
         

--- a/src/axis_camera/axis_ptz_node.py
+++ b/src/axis_camera/axis_ptz_node.py
@@ -57,6 +57,8 @@ from robotnik_msgs.srv import SetInt16, SetInt16Response
 from robotnik_msgs.srv import SetString, SetStringResponse
 from robotnik_msgs.srv import GetStringList, GetStringListResponse
 from robotnik_msgs.srv import GetImageSettings, GetImageSettingsResponse
+from robotnik_msgs.srv import SetAutoTracking, SetAutoTrackingResponse
+from std_msgs.msg import Bool
 
 class AxisPTZ(threading.Thread):
     """
@@ -132,6 +134,9 @@ class AxisPTZ(threading.Thread):
         self.iris_min_value = 1.0
         self.iris_max_value = 9999.0
         self.iris_two_step_control = args.get('iris_two_step_control', False)
+
+        # Auto-tracking state
+        self.autotracking_active = False
 
         # Detect effective focus range at runtime
         self.effective_focus_min_raw = None
@@ -282,6 +287,8 @@ class AxisPTZ(threading.Thread):
         self.set_white_balance_service = rospy.Service('~set_white_balance', SetString, self.setWhiteBalanceServiceCb)
         self.get_white_balance_mode_service = rospy.Service('~get_white_balance_mode', GetStringList, self.getWhiteBalanceModeServiceCb)
         self.get_image_settings_service = rospy.Service('~get_image_settings', GetImageSettings, self.getImageSettingsServiceCb)
+        self.autotracking_pub = rospy.Publisher('~autotracking_active', Bool, queue_size=10, latch=True)
+        self.set_autotracking_service = rospy.Service('~set_autotracking', SetAutoTracking, self.setAutoTrackingServiceCb)
         self.loadDeviceInfo()
         self.device_info_service = rospy.Service('~get_device_info', GetAxisDeviceInfo, self.getDeviceInfoServiceCb)
 
@@ -324,11 +331,28 @@ class AxisPTZ(threading.Thread):
             firmware=self.device_firmware
         )
 
+    def setAutoTrackingServiceCb(self, req):
+        response = SetAutoTrackingResponse()
+        result = self.controller.setAutoTracking(req.enable)
+        response.success = result['success']
+        response.message = result['message']
+        if result['success']:
+            self.autotracking_active = req.enable
+            self.autotracking_pub.publish(Bool(data=self.autotracking_active))
+            rospy.loginfo('%s:setAutoTrackingServiceCb: %s', rospy.get_name(), result['message'])
+        else:
+            rospy.logerr('%s:setAutoTrackingServiceCb: %s', rospy.get_name(), result['message'])
+        return response
+
     def commandPTZCb(self, msg):
         """
             Command for ptz movements
         """
         self.t_last_command_time = rospy.Time.now()
+
+        if self.autotracking_active:
+            rospy.logwarn_throttle(5, '%s:commandPTZCb: ignoring PTZ command, auto-tracking is active', rospy.get_name())
+            return
 
         if self.ptz_syncronized:
             self.setCommandPTZ(msg)
@@ -658,6 +682,9 @@ class AxisPTZ(threading.Thread):
         """
         t_now = rospy.Time.now()
 
+        if self.autotracking_active:
+            return
+
         if self.control_mode == 'position':
             # Only if it's syncronized
             if self.ptz_syncronized:
@@ -838,6 +865,8 @@ class AxisPTZ(threading.Thread):
         zoom_parameters.zoom_augments = self.zoom_augments
 
         self.zoom_parameter_pub.publish(zoom_parameters)
+        # Publishes the auto-tracking state
+        self.autotracking_pub.publish(Bool(data=self.autotracking_active))
         # Publishes the current PTZ values
         self.pub.publish(self.current_ptz)
         


### PR DESCRIPTION
# Summary
Implements automatic tracking control with fallback endpoints:
- VAPIX operator.cgi as the primary option
- Local ACAP settings.fcgi endpoint as a fallback
- Adds periodic synchronization of the automatic tracking status to reflect external changes (web interface/VMS)
- Suppresses manual PTZ commands when auto-tracking is active to prevent interference
- Improves error messages when the model/application does not support auto-tracking
- Updates the README documentation with behavior, fallback, and status synchronization

## Validation performed:

- The set_autotracking service is enabled/disabled correctly
- The autotracking_active topic is updated by the service and by detected external changes
- With automatic tracking active, manual PTZ commands are blocked

## How to test:
Topic
```
rostopic echo /axis_camera_ptz/autotracking_active
```
Enable auto-tracking
```
rosservice call /axis_camera_ptz/set_autotracking "enable: true"
```
Disable auto-tracking
```
rosservice call /axis_camera_ptz/set_autotracking "enable: false"
```