### PR TITLE
Feat/autotracking mode selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ catkin_python_setup()
 add_message_files(DIRECTORY msg 
 FILES
    Axis.msg
+  AxisMetadataDetection.msg
+  AxisMetadataDetectionArray.msg
    ptz.msg
    inputs_outputs.msg
 )
@@ -50,6 +52,9 @@ catkin_install_python(PROGRAMS src/axis_camera/__init__.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 catkin_install_python(PROGRAMS src/axis_camera/axis_ptz_node.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+catkin_install_python(PROGRAMS src/axis_camera/axis_detection_node.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
   
 catkin_install_python(PROGRAMS src/axis_camera/axis_stream_node.py

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ roslaunch axis_camera axis_ptz.launch ip_address:=<camera_ip>
 * `~camera_parameters` (`robotnik_msgs/CameraParameters`) — Zoom range and step configuration.
 * `~joint_states` (`sensor_msgs/JointState`) — Pan, tilt and zoom as joint positions.
 * `~autotracking_active` (`std_msgs/Bool`) — Current auto-tracking state. Latched topic; `true` when auto-tracking is active, `false` otherwise.
+* `~autotracking_status` (`robotnik_msgs/AutoTrackingStatus`) — Extended auto-tracking status including `enabled`, `requested_mode`, `active_mode`, and `fallback_applied`.
 * `~image_settings` (`robotnik_msgs/ImageSettings`) — Current image settings published at `image_settings_pub_rate`. The `is_valid` field indicates whether all fields were successfully read from the camera. On cameras with limited VAPIX read support, last-known values may be used as a fallback (see [Image settings behaviour](#image-settings-behaviour)).
 
 ### Subscribed Topics
@@ -184,25 +185,47 @@ auto: false"
 ```
 
 #### `~set_autotracking` (`robotnik_msgs/SetAutoTracking`)
-Enables or disables auto-tracking on supported camera models.
+Enables or disables auto-tracking on supported camera models and requests an auto-tracking mode.
 
 **Important**: When auto-tracking is active, manual PTZ commands are suppressed by the camera. The node honors this by not sending PTZ commands while `~autotracking_active` is true.
 
 
 Request fields:
-* `enable` (`bool`): if `true`, enable auto-tracking; if `false`, disable it.
+* `enabled` (`bool`): if `true`, enable auto-tracking; if `false`, disable it.
+* `mode` (`string`): requested mode. Supported values: `motion`, `person`, `vehicle`, `auto`.
 
 Response fields:
 * `success` (`bool`): `true` if the command succeeded; `false` if the camera does not support auto-tracking or a communication error occurred.
+* `applied_mode` (`string`): mode effectively applied by the node/camera.
+* `fallback_applied` (`bool`): `true` when the requested mode is unsupported and the node falls back to `motion`.
 * `message` (`string`): status or error message.
 
 Examples:
 ```bash
-# Enable auto-tracking
-rosservice call /axis_camera_ptz/set_autotracking "enable: true"
+# Enable auto-tracking in motion mode
+rosservice call /axis_camera_ptz/set_autotracking "enabled: true
+mode: 'motion'"
 
 # Disable auto-tracking
-rosservice call /axis_camera_ptz/set_autotracking "enable: false"
+rosservice call /axis_camera_ptz/set_autotracking "enabled: false
+mode: 'auto'"
+
+# Request person mode
+rosservice call /axis_camera_ptz/set_autotracking "enabled: true
+mode: 'person'"
+```
+
+#### `~get_autotracking_capabilities` (`robotnik_msgs/GetAutoTrackingCapabilities`)
+Returns the currently detected auto-tracking capabilities and active mode.
+
+Response fields:
+* `supported_modes` (`string[]`): modes supported by the connected device, derived from Object Analytics capabilities.
+* `current_mode` (`string`): mode currently active in the camera/Object Analytics configuration.
+* `enabled` (`bool`): current auto-tracking enabled state.
+
+Example:
+```bash
+rosservice call /axis_camera_ptz/get_autotracking_capabilities
 ```
 
 > **Note on service names**: service names depend on the node namespace. Run `rosservice list` to get the exact names in your setup.
@@ -279,6 +302,11 @@ relative: false"
 * Auto-tracking is controlled via two endpoints tried in order:
   1. **VAPIX PTZ Autotracking API** (`/axis-cgi/ptz-autotracking/operator.cgi`) — official endpoint available on cameras with firmware ≥ 10.x.
   2. **PTZ Autotracker ACAP app** (`/local/axis-ptz-autotracking/settings.fcgi`) — the app's own REST API, used by the camera web UI. Available on any camera with the PTZ Autotracker ACAP app installed.
+* The driver detects supported modes from Axis Object Analytics capabilities and exposes them through `~get_autotracking_capabilities`.
+* Requested modes `person` and `vehicle` are applied through Axis Object Analytics configuration. If a requested mode is not supported, the node falls back to `motion` and reports `fallback_applied=true`.
+* On devices that only provide basic on/off autotracking, `motion` still works even when Object Analytics is not available.
+* `active_mode` in `~autotracking_status` reflects the mode actually applied, which may differ from `requested_mode` after a fallback.
+* On some Axis models, PTZ autotracking may still follow generic motion even when Object Analytics is configured for `person` or `vehicle`. In that case, the selected mode still reflects the analytics configuration and reported capabilities, but PTZ target filtering remains camera-dependent.
 * If neither endpoint responds, `success=false` is returned with a descriptive message (e.g. app not installed).
 * While auto-tracking is active, the node suppresses all outgoing PTZ commands (both topic-based commands and the continuous control loop).
 * The node polls the camera every 2 seconds to detect state changes made outside ROS (e.g. via the camera web UI or VMS). The `~autotracking_active` topic is updated automatically if a change is detected.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ roslaunch axis_camera axis_ptz.launch ip_address:=<camera_ip>
 * `~camera_params` (`robotnik_msgs/Axis`) — Current PTZ state. `focus` and `iris` fields are published as percentage (0–100).
 * `~camera_parameters` (`robotnik_msgs/CameraParameters`) — Zoom range and step configuration.
 * `~joint_states` (`sensor_msgs/JointState`) — Pan, tilt and zoom as joint positions.
+* `~autotracking_active` (`std_msgs/Bool`) — Current auto-tracking state. Latched topic; `true` when auto-tracking is active, `false` otherwise.
 * `~image_settings` (`robotnik_msgs/ImageSettings`) — Current image settings published at `image_settings_pub_rate`. The `is_valid` field indicates whether all fields were successfully read from the camera. On cameras with limited VAPIX read support, last-known values may be used as a fallback (see [Image settings behaviour](#image-settings-behaviour)).
 
 ### Subscribed Topics
@@ -180,6 +181,28 @@ auto: true"
 # Set manual iris to 75%
 rosservice call /axis_camera_ptz/set_iris "value: 75.0
 auto: false"
+```
+
+#### `~set_autotracking` (`robotnik_msgs/SetAutoTracking`)
+Enables or disables auto-tracking on supported camera models.
+
+**Important**: When auto-tracking is active, manual PTZ commands are suppressed by the camera. The node honors this by not sending PTZ commands while `~autotracking_active` is true.
+
+
+Request fields:
+* `enable` (`bool`): if `true`, enable auto-tracking; if `false`, disable it.
+
+Response fields:
+* `success` (`bool`): `true` if the command succeeded; `false` if the camera does not support auto-tracking or a communication error occurred.
+* `message` (`string`): status or error message.
+
+Examples:
+```bash
+# Enable auto-tracking
+rosservice call /axis_camera_ptz/set_autotracking "enable: true"
+
+# Disable auto-tracking
+rosservice call /axis_camera_ptz/set_autotracking "enable: false"
 ```
 
 > **Note on service names**: service names depend on the node namespace. Run `rosservice list` to get the exact names in your setup.

--- a/README.md
+++ b/README.md
@@ -274,6 +274,15 @@ relative: false"
 * `zoom` as float (proportional value between `min_zoom_augment` and `max_zoom_augment`)
 * `relative` as bool — if `true`, values are added to the current position
 
+### Auto-tracking behaviour
+
+* Auto-tracking is controlled via two endpoints tried in order:
+  1. **VAPIX PTZ Autotracking API** (`/axis-cgi/ptz-autotracking/operator.cgi`) — official endpoint available on cameras with firmware ≥ 10.x.
+  2. **PTZ Autotracker ACAP app** (`/local/axis-ptz-autotracking/settings.fcgi`) — the app's own REST API, used by the camera web UI. Available on any camera with the PTZ Autotracker ACAP app installed.
+* If neither endpoint responds, `success=false` is returned with a descriptive message (e.g. app not installed).
+* While auto-tracking is active, the node suppresses all outgoing PTZ commands (both topic-based commands and the continuous control loop).
+* The node polls the camera every 2 seconds to detect state changes made outside ROS (e.g. via the camera web UI or VMS). The `~autotracking_active` topic is updated automatically if a change is detected.
+
 ### Focus and iris behaviour
 
 * Focus and iris limits are **read from the camera at startup** and used to map between raw camera units and percentage.

--- a/launch/axis.launch
+++ b/launch/axis.launch
@@ -26,6 +26,7 @@
 	<arg name="tilt_joint" default="$(arg prefix)$(arg node_name)_tilt_joint"/>
 	<arg name="initialization_delay" default="0.0"/>
 	<arg name="send_constantly" default="false"/>
+	<arg name="run_detection" default="true"/>
 
 	<param name="hostname" value="$(arg ip_address)"/>
 	<param name="username" value="$(arg username)" />
@@ -49,6 +50,9 @@
 	<param name="camera_info_url" value="$(arg camera_info_url)"/>
 
 	<node pkg="axis_camera" type="axis_ptz_node.py" name="$(arg node_name)" output="screen" required="true"/>
+	<node pkg="axis_camera" type="axis_detection_node.py" name="$(arg node_name)_detection" output="screen" if="$(arg run_detection)">
+		<param name="hostname" value="$(arg ip_address)"/>
+	</node>
 	<!-- Republishes from Compressed to raw -->
 	<node pkg="image_transport" type="republish" name="$(arg node_name)_republisher" output="screen" args="compressed in:= raw out:=image_raw" if="$(arg run_republish)"/>
 	<!-- IMAGE PROC: Republish image topics by using camera info -->

--- a/launch/axis_ptz.launch
+++ b/launch/axis_ptz.launch
@@ -16,6 +16,7 @@
 	<arg name="zoom_joint" default="$(arg prefix)$(arg node_name)_zoom_joint"/>
 	<arg name="initialization_delay" default="0.0"/>
 	<arg name="send_constantly" default="false"/>
+	<arg name="run_detection" default="true"/>
 
 	<rosparam file="$(arg ptz_config_file)" command="load" if="$(arg ptz_enabled)"/>
 	<param name="hostname" value="$(arg ip_address)"/>
@@ -30,4 +31,7 @@
 	<param name="send_constantly" value="$(arg send_constantly)"/>
 
 	<node pkg="axis_camera" type="axis_ptz_node.py" name="$(arg node_name)_ptz" output="screen" required="true"/>
+	<node pkg="axis_camera" type="axis_detection_node.py" name="$(arg node_name)_detection" output="screen" if="$(arg run_detection)">
+		<param name="hostname" value="$(arg ip_address)"/>
+	</node>
 </launch>

--- a/msg/AxisMetadataDetection.msg
+++ b/msg/AxisMetadataDetection.msg
@@ -1,0 +1,16 @@
+std_msgs/Header header
+
+# Track ID from Axis metadata stream
+string track_id
+
+# Class label (e.g. "human", "vehicle", "unknown")
+string class_label
+
+# Detection confidence [0.0 - 1.0], may be 0.0 when unavailable
+float32 score
+
+# Bounding box in normalized coordinates [0.0 - 1.0]
+float32 left
+float32 top
+float32 right
+float32 bottom

--- a/msg/AxisMetadataDetectionArray.msg
+++ b/msg/AxisMetadataDetectionArray.msg
@@ -1,0 +1,4 @@
+std_msgs/Header header
+
+# Filtered detections in the current metadata frame
+axis_camera/AxisMetadataDetection[] detections

--- a/src/axis_camera/axis_detection_node.py
+++ b/src/axis_camera/axis_detection_node.py
@@ -32,6 +32,9 @@ class AxisMetadataDetectionNode(object):
             rospy.logwarn('%s: invalid ~filter_class=%s, using all', rospy.get_name(), self.filter_class)
             self.filter_class = 'all'
 
+        # Publish initial value so rosparam get works from startup
+        rospy.set_param('~filter_class', self.filter_class)
+
         self.pub_filtered = rospy.Publisher('~metadata_filtered', AxisMetadataDetectionArray, queue_size=10)
 
         scheme = 'wss' if self.use_tls else 'ws'

--- a/src/axis_camera/axis_detection_node.py
+++ b/src/axis_camera/axis_detection_node.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python
+
+import json
+import ssl
+import threading
+
+import rospy
+from std_msgs.msg import Header
+
+from axis_camera.msg import AxisMetadataDetection, AxisMetadataDetectionArray
+
+try:
+    import websocket
+except ImportError:
+    websocket = None
+
+
+class AxisMetadataDetectionNode(object):
+    def __init__(self):
+        if websocket is None:
+            raise RuntimeError('python websocket-client is required: pip install websocket-client')
+
+        self.hostname = rospy.get_param('~hostname', '192.168.1.205')
+        self.use_tls = bool(rospy.get_param('~use_tls', False))
+        self.ws_source = rospy.get_param('~ws_source', 'analytics-scene-description')
+        self.channel_filter = rospy.get_param('~channel_filter', ['1'])
+        self.filter_class = str(rospy.get_param('~filter_class', 'all')).strip().lower()
+
+        self.channel_filter = self._normalize_channel_filter(self.channel_filter)
+
+        if self.filter_class not in ('all', 'human', 'vehicle'):
+            rospy.logwarn('%s: invalid ~filter_class=%s, using all', rospy.get_name(), self.filter_class)
+            self.filter_class = 'all'
+
+        self.pub_filtered = rospy.Publisher('~metadata_filtered', AxisMetadataDetectionArray, queue_size=10)
+
+        scheme = 'wss' if self.use_tls else 'ws'
+        self.ws_url = '%s://%s/vapix/ws-data-stream?sources=%s' % (scheme, self.hostname, self.ws_source)
+
+        self._configured = threading.Event()
+        self._stop = threading.Event()
+        self._ws = None
+        self._last_runtime_param_check = 0.0
+
+    def _normalize_channel_filter(self, raw_filter):
+        if isinstance(raw_filter, str):
+            raw_filter = [raw_filter]
+        if not isinstance(raw_filter, list) or len(raw_filter) == 0:
+            raw_filter = ['1']
+        return [str(ch) for ch in raw_filter]
+
+    def _reload_runtime_params(self):
+        now = rospy.Time.now().to_sec()
+        if now - self._last_runtime_param_check < 1.0:
+            return
+        self._last_runtime_param_check = now
+
+        new_filter_class = str(rospy.get_param('~filter_class', self.filter_class)).strip().lower()
+        if new_filter_class not in ('all', 'human', 'vehicle'):
+            rospy.logwarn_throttle(10, '%s: ignoring invalid ~filter_class=%s', rospy.get_name(), new_filter_class)
+        elif new_filter_class != self.filter_class:
+            rospy.loginfo('%s: runtime filter_class changed %s -> %s', rospy.get_name(), self.filter_class, new_filter_class)
+            self.filter_class = new_filter_class
+
+        raw_channel_filter = rospy.get_param('~channel_filter', self.channel_filter)
+        new_channel_filter = self._normalize_channel_filter(raw_channel_filter)
+        if new_channel_filter != self.channel_filter:
+            self.channel_filter = new_channel_filter
+            rospy.loginfo('%s: runtime channel_filter changed to %s', rospy.get_name(), self.channel_filter)
+            try:
+                if self._ws is not None:
+                    self._ws.send(json.dumps(self._build_configure_payload()))
+                    rospy.loginfo('%s: configure resent with channelFilter=%s', rospy.get_name(), self.channel_filter)
+            except Exception as exc:
+                rospy.logwarn('%s: failed to resend configure payload: %s', rospy.get_name(), exc)
+
+    def _allowed_class(self, cls):
+        normalized = str(cls or '').strip().lower()
+        if self.filter_class == 'all':
+            return normalized in ('human', 'vehicle')
+        return normalized == self.filter_class
+
+    def _build_configure_payload(self):
+        return {
+            'apiVersion': '1.0',
+            'method': '%s:configure' % self.ws_source,
+            'params': {
+                'channelFilter': self.channel_filter,
+            }
+        }
+
+    def _publish_detections(self, observations):
+        out = AxisMetadataDetectionArray()
+        out.header = Header(stamp=rospy.Time.now(), frame_id='axis_camera')
+
+        for obs in observations:
+            if not isinstance(obs, dict):
+                continue
+
+            bbox = obs.get('bounding_box', {})
+            if not isinstance(bbox, dict):
+                continue
+
+            cls_obj = obs.get('class', {})
+            if not isinstance(cls_obj, dict):
+                cls_obj = {}
+
+            class_label = str(cls_obj.get('type', 'unknown')).strip().lower()
+            if not self._allowed_class(class_label):
+                continue
+
+            left = bbox.get('left')
+            top = bbox.get('top')
+            right = bbox.get('right')
+            bottom = bbox.get('bottom')
+            if None in (left, top, right, bottom):
+                continue
+
+            det = AxisMetadataDetection()
+            det.header = out.header
+            det.track_id = str(obs.get('track_id', ''))
+            det.class_label = class_label if class_label else 'unknown'
+            det.score = float(cls_obj.get('score', 0.0) or 0.0)
+            det.left = float(left)
+            det.top = float(top)
+            det.right = float(right)
+            det.bottom = float(bottom)
+
+            out.detections.append(det)
+
+        if out.detections:
+            self.pub_filtered.publish(out)
+
+    def _extract_observations(self, msg_obj):
+        try:
+            return msg_obj['params']['notification']['message']['data']['frame']['observations']
+        except Exception:
+            return None
+
+    def _on_open(self, ws):
+        rospy.loginfo('%s: connected to %s', rospy.get_name(), self.ws_url)
+        payload = self._build_configure_payload()
+        ws.send(json.dumps(payload))
+        rospy.loginfo('%s: configure sent with channelFilter=%s', rospy.get_name(), self.channel_filter)
+
+    def _on_message(self, ws, msg):
+        self._reload_runtime_params()
+
+        try:
+            obj = json.loads(msg)
+        except Exception:
+            return
+
+        error = obj.get('error')
+        if isinstance(error, dict):
+            rospy.logwarn_throttle(10, '%s: metadata ws error: %s', rospy.get_name(), error)
+            return
+
+        method = obj.get('method')
+        if method == '%s:configure' % self.ws_source:
+            self._configured.set()
+            rospy.loginfo('%s: metadata configure accepted', rospy.get_name())
+            return
+
+        observations = self._extract_observations(obj)
+        if isinstance(observations, list):
+            self._publish_detections(observations)
+
+    def _on_error(self, ws, err):
+        rospy.logwarn_throttle(5, '%s: metadata ws error: %s', rospy.get_name(), err)
+
+    def _on_close(self, ws, code, reason):
+        rospy.logwarn('%s: metadata ws closed (%s, %s)', rospy.get_name(), code, reason)
+
+    def spin(self):
+        while not rospy.is_shutdown() and not self._stop.is_set():
+            self._configured.clear()
+            self._ws = websocket.WebSocketApp(
+                self.ws_url,
+                on_open=self._on_open,
+                on_message=self._on_message,
+                on_error=self._on_error,
+                on_close=self._on_close,
+            )
+            try:
+                if self.use_tls:
+                    self._ws.run_forever(
+                        sslopt={'cert_reqs': ssl.CERT_NONE},
+                        ping_interval=20,
+                        ping_timeout=10,
+                    )
+                else:
+                    self._ws.run_forever(ping_interval=20, ping_timeout=10)
+            except Exception as exc:
+                rospy.logwarn('%s: metadata ws exception: %s', rospy.get_name(), exc)
+
+            if rospy.is_shutdown() or self._stop.is_set():
+                break
+
+            rospy.sleep(2.0)
+
+    def stop(self):
+        self._stop.set()
+        try:
+            if self._ws is not None:
+                self._ws.close()
+        except Exception:
+            pass
+
+
+def main():
+    rospy.init_node('axis_detection_node')
+    node = AxisMetadataDetectionNode()
+    rospy.on_shutdown(node.stop)
+    node.spin()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/axis_camera/axis_lib/axis_control.py
+++ b/src/axis_camera/axis_lib/axis_control.py
@@ -619,6 +619,39 @@ class ControlAxis():
             conn.close()
         return ret
 
+    def setAutoTracking(self, enable):
+        """
+        Enables or disables auto-tracking via VAPIX.
+        Returns a dict with keys: success (bool), message (str).
+        HTTP 204 => success; HTTP 400 => not supported by this model.
+        """
+        ret = {'success': False, 'message': ''}
+        conn = httplib.HTTPConnection(self.hostname)
+        value = 'on' if enable else 'off'
+        url = '/axis-cgi/com/ptz.cgi?autotrack=%s&camera=1' % value
+        try:
+            conn.request("GET", url)
+            response = conn.getresponse()
+            response.read()  # drain body
+            if response.status == 204:
+                ret['success'] = True
+                ret['message'] = 'Auto-tracking %s' % ('enabled' if enable else 'disabled')
+            elif response.status == 400:
+                ret['success'] = False
+                ret['message'] = 'Auto-tracking not supported by this camera model (HTTP 400)'
+            else:
+                ret['success'] = False
+                ret['message'] = 'Unexpected HTTP status %d while setting auto-tracking' % response.status
+        except socket.error as e:
+            ret['success'] = False
+            ret['message'] = 'Connection error: %s' % str(e)
+        except socket.timeout as e:
+            ret['success'] = False
+            ret['message'] = 'Connection timeout: %s' % str(e)
+        finally:
+            conn.close()
+        return ret
+
     def getPTZState(self):
         """
             Gets the current ptz state/position of the camera

--- a/src/axis_camera/axis_lib/axis_control.py
+++ b/src/axis_camera/axis_lib/axis_control.py
@@ -657,6 +657,42 @@ class ControlAxis():
         except (urllib_error.URLError, socket.timeout) as e:
             return False, 'VAPIX operator.cgi connection error: %s' % str(e)
 
+    def _try_autotracking_admin(self, opener, enable):
+        """
+        Tries to set autotracking via VAPIX PTZ Autotracking admin endpoint.
+        Returns (success, message) tuple. success=None means 404 => try fallback.
+        """
+        url = 'http://%s/axis-cgi/ptz-autotracking/admin.cgi' % self.hostname
+        payload = {
+            'apiVersion': '1.0',
+            'method': 'setAutotrackingState',
+            'params': {'enabled': bool(enable)}
+        }
+        try:
+            request = urllib_request.Request(
+                url,
+                data=json.dumps(payload).encode('utf-8'),
+                headers={'Content-Type': 'application/json', 'Accept': 'application/json'}
+            )
+            response = opener.open(request, timeout=5)
+            body = response.read().decode('utf-8', errors='replace').strip()
+            if response.getcode() in (200, 204):
+                if body:
+                    try:
+                        body_json = json.loads(body)
+                    except Exception:
+                        body_json = None
+                    if isinstance(body_json, dict) and isinstance(body_json.get('error'), dict):
+                        return False, 'VAPIX admin.cgi error: %s' % str(body_json['error'].get('code'))
+                return True, 'Auto-tracking %s via VAPIX admin.cgi' % ('enabled' if enable else 'disabled')
+            return False, 'VAPIX admin.cgi HTTP %d' % response.getcode()
+        except urllib_error.HTTPError as e:
+            if e.code == 404:
+                return None, 'VAPIX admin.cgi not found (404)'
+            return False, 'VAPIX admin.cgi HTTP error %d: %s' % (e.code, e.reason)
+        except (urllib_error.URLError, socket.timeout) as e:
+            return False, 'VAPIX admin.cgi connection error: %s' % str(e)
+
     def _try_autotracking_acap(self, opener, enable):
         """
         Tries to set autotracking via the PTZ Autotracker ACAP app local endpoint.
@@ -699,10 +735,12 @@ class ControlAxis():
         """
         Enables or disables auto-tracking on Axis PTZ cameras.
 
-        Uses a two-tier approach to support a wide range of camera models:
-          1. VAPIX PTZ Autotracking API (/axis-cgi/ptz-autotracking/operator.cgi)
-             - Official Axis API, available on cameras with firmware >= 10.x
-          2. PTZ Autotracker ACAP app local API (/local/axis-ptz-autotracking/settings.fcgi)
+          Uses a three-tier approach to support a wide range of camera models:
+             1. VAPIX PTZ Autotracking admin API (/axis-cgi/ptz-autotracking/admin.cgi)
+                 - Newer firmware endpoint.
+             2. VAPIX PTZ Autotracking operator API (/axis-cgi/ptz-autotracking/operator.cgi)
+                 - Legacy endpoint.
+             3. PTZ Autotracker ACAP app local API (/local/axis-ptz-autotracking/settings.fcgi)
              - The app's own REST endpoint, used by the web UI, available on any
                camera with the PTZ Autotracker ACAP app installed (e.g. P5676-LE)
 
@@ -711,7 +749,17 @@ class ControlAxis():
         ret = {'success': False, 'message': ''}
         opener = self._get_digest_opener()
 
-        # 1. Try official VAPIX endpoint first
+        # 1. Try VAPIX admin endpoint first
+        success, message = self._try_autotracking_admin(opener, enable)
+        if success is True:
+            ret['success'] = True
+            ret['message'] = message
+            return ret
+        if success is False:
+            ret['message'] = message
+            return ret
+
+        # 2. Try legacy VAPIX endpoint
         success, message = self._try_autotracking_vapix(opener, enable)
         if success is True:
             ret['success'] = True
@@ -722,7 +770,7 @@ class ControlAxis():
             return ret
 
         # success is None => 404, fall through to ACAP app endpoint
-        # 2. Fall back to ACAP app local endpoint
+        # 3. Fall back to ACAP app local endpoint
         success, message = self._try_autotracking_acap(opener, enable)
         ret['success'] = success
         ret['message'] = message
@@ -818,6 +866,7 @@ class ControlAxis():
         """
         opener = self._get_digest_opener()
         urls = (
+            'http://%s/axis-cgi/ptz-autotracking/admin.cgi' % self.hostname,
             'http://%s/axis-cgi/ptz-autotracking/operator.cgi' % self.hostname,
             'http://%s/local/axis-ptz-autotracking/settings.fcgi' % self.hostname,
         )
@@ -833,6 +882,318 @@ class ControlAxis():
             'success': False,
             'enabled': None,
             'message': '; '.join(errors)
+        }
+
+    _AOA_CONTROL_PATH = '/local/objectanalytics/control.cgi'
+    _AOA_MODE_TO_CLASSES = {
+        # Confirmed from AOA UI payloads:
+        # motion  -> objectClassifications omitted
+        # person  -> [{'type': 'human'}]
+        # vehicle -> [{'type': 'vehicle'}]
+        'motion': tuple(),
+        'person': ('human',),
+        'vehicle': ('vehicle',),
+    }
+
+    def _normalize_tracking_mode(self, mode):
+        if mode is None:
+            return 'auto'
+        lowered = str(mode).strip().lower()
+        alias = {
+            'human': 'person',
+            'people': 'person',
+            'car': 'vehicle',
+            'movement': 'motion',
+        }
+        return alias.get(lowered, lowered)
+
+    def _call_aoa(self, opener, method, params):
+        url = 'http://%s%s' % (self.hostname, self._AOA_CONTROL_PATH)
+        payload = {
+            'apiVersion': '1.3',
+            'context': 'AOA_NATIVE_UI',
+            'method': method,
+            'params': params,
+        }
+        request = urllib_request.Request(
+            url,
+            data=json.dumps(payload).encode('utf-8'),
+            headers={
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'X-Requested-With': 'XMLHttpRequest',
+            }
+        )
+        response = opener.open(request, timeout=5)
+        body = response.read().decode('utf-8', errors='replace').strip()
+        return response.getcode(), json.loads(body) if body else {}
+
+    def _get_aoa_configuration(self, opener):
+        try:
+            status, body = self._call_aoa(opener, 'getConfiguration', {})
+            if status not in (200, 204):
+                return None, 'AOA getConfiguration HTTP %d' % status
+            if isinstance(body.get('error'), dict):
+                return None, 'AOA getConfiguration error: %s' % body['error'].get('message', body['error'])
+            data = body.get('data')
+            if not isinstance(data, dict):
+                return None, 'AOA getConfiguration returned no data'
+            return data, 'AOA configuration read'
+        except urllib_error.HTTPError as e:
+            if e.code == 404:
+                return None, 'AOA control.cgi not found (404)'
+            return None, 'AOA getConfiguration HTTP error %d: %s' % (e.code, e.reason)
+        except (urllib_error.URLError, socket.timeout) as e:
+            return None, 'AOA getConfiguration connection error: %s' % str(e)
+        except Exception as e:
+            return None, 'AOA getConfiguration parse error: %s' % str(e)
+
+    def _get_aoa_configuration_capabilities(self, opener):
+        try:
+            status, body = self._call_aoa(opener, 'getConfigurationCapabilities', {})
+            if status not in (200, 204):
+                return None, 'AOA getConfigurationCapabilities HTTP %d' % status
+            if isinstance(body.get('error'), dict):
+                return None, 'AOA getConfigurationCapabilities error: %s' % body['error'].get('message', body['error'])
+            data = body.get('data')
+            if not isinstance(data, dict):
+                return None, 'AOA getConfigurationCapabilities returned no data'
+            return data, 'AOA configuration capabilities read'
+        except urllib_error.HTTPError as e:
+            if e.code == 404:
+                return None, 'AOA control.cgi not found (404)'
+            return None, 'AOA getConfigurationCapabilities HTTP error %d: %s' % (e.code, e.reason)
+        except (urllib_error.URLError, socket.timeout) as e:
+            return None, 'AOA getConfigurationCapabilities connection error: %s' % str(e)
+        except Exception as e:
+            return None, 'AOA getConfigurationCapabilities parse error: %s' % str(e)
+
+    def _extract_supported_modes_from_aoa_capabilities(self, capabilities):
+        supported_modes = set(['motion'])
+
+        scenarios = capabilities.get('scenarios', {}) if isinstance(capabilities, dict) else {}
+        supported_scenarios = scenarios.get('supportedScenarios', []) if isinstance(scenarios, dict) else []
+        if isinstance(supported_scenarios, list) and 'motion' not in supported_scenarios:
+            supported_modes.discard('motion')
+
+        def walk_classifications(items):
+            if not isinstance(items, list):
+                return
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                item_type = str(item.get('type', '')).strip().lower()
+                if item_type == 'human':
+                    supported_modes.add('person')
+                elif item_type == 'vehicle':
+                    supported_modes.add('vehicle')
+                walk_classifications(item.get('subTypes', []))
+
+        walk_classifications(capabilities.get('objectClassifications', []))
+
+        if not supported_modes:
+            supported_modes.add('motion')
+
+        ordered = [mode for mode in ('motion', 'person', 'vehicle') if mode in supported_modes]
+        return ordered if ordered else ['motion']
+
+    def _mode_from_aoa_configuration(self, config):
+        scenarios = config.get('scenarios', []) if isinstance(config, dict) else []
+        if not scenarios:
+            return 'motion'
+
+        saw_motion_pattern = False
+        classes = set()
+        for scenario in scenarios:
+            if not isinstance(scenario, dict):
+                continue
+            object_classifications = scenario.get('objectClassifications')
+            if object_classifications is None:
+                saw_motion_pattern = True
+                continue
+            if not isinstance(object_classifications, list) or len(object_classifications) == 0:
+                saw_motion_pattern = True
+                continue
+            for item in object_classifications:
+                if not isinstance(item, dict):
+                    continue
+                t = str(item.get('type', '')).strip().lower()
+                if t == 'human':
+                    classes.add('person')
+                elif t == 'vehicle':
+                    classes.add('vehicle')
+
+        if saw_motion_pattern:
+            return 'motion'
+        if classes == {'person'}:
+            return 'person'
+        if classes == {'vehicle'}:
+            return 'vehicle'
+        return 'motion'
+
+    def _prepare_aoa_configuration_for_mode(self, config, mode):
+        updated = json.loads(json.dumps(config))
+        scenarios = updated.get('scenarios', [])
+        if not isinstance(scenarios, list):
+            return updated
+
+        if mode == 'motion':
+            for scenario in scenarios:
+                if isinstance(scenario, dict) and 'objectClassifications' in scenario:
+                    del scenario['objectClassifications']
+            return updated
+
+        desired = [{'type': t} for t in self._AOA_MODE_TO_CLASSES[mode]]
+        for scenario in scenarios:
+            if not isinstance(scenario, dict):
+                continue
+            scenario['objectClassifications'] = list(desired)
+        return updated
+
+    def _set_aoa_mode(self, opener, mode):
+        config, message = self._get_aoa_configuration(opener)
+        if config is None:
+            if 'not found (404)' in message:
+                return None, message
+            return False, message
+
+        new_config = self._prepare_aoa_configuration_for_mode(config, mode)
+        try:
+            status, body = self._call_aoa(opener, 'setConfiguration', new_config)
+            if status not in (200, 204):
+                return False, 'AOA setConfiguration HTTP %d' % status
+            if isinstance(body.get('error'), dict):
+                return False, 'AOA setConfiguration error: %s' % body['error'].get('message', body['error'])
+
+            verify_config, verify_message = self._get_aoa_configuration(opener)
+            if verify_config is None:
+                return False, 'AOA setConfiguration accepted but verify failed: %s' % verify_message
+            effective_mode = self._mode_from_aoa_configuration(verify_config)
+            if effective_mode != mode:
+                return False, 'AOA setConfiguration accepted but effective mode is %s (requested %s)' % (effective_mode, mode)
+            return True, 'mode %s applied via AOA control.cgi' % mode
+        except urllib_error.HTTPError as e:
+            if e.code == 404:
+                return None, 'AOA control.cgi not found (404)'
+            return False, 'AOA setConfiguration HTTP error %d: %s' % (e.code, e.reason)
+        except (urllib_error.URLError, socket.timeout) as e:
+            return False, 'AOA setConfiguration connection error: %s' % str(e)
+
+    def setAutoTrackingWithMode(self, enabled, mode='auto'):
+        """
+        Enables/disables autotracking and applies tracking mode when requested.
+        Supported modes: motion | person | vehicle | auto
+        """
+        normalized_mode = self._normalize_tracking_mode(mode)
+        if normalized_mode not in ('auto', 'motion', 'person', 'vehicle'):
+            return {
+                'success': False,
+                'applied_mode': 'motion',
+                'fallback_applied': False,
+                'message': 'unsupported mode "%s"; expected motion|person|vehicle|auto' % str(mode)
+            }
+
+        toggle_result = self.setAutoTracking(enabled)
+        if not toggle_result.get('success'):
+            return {
+                'success': False,
+                'applied_mode': 'motion',
+                'fallback_applied': False,
+                'message': toggle_result.get('message', 'failed to toggle autotracking')
+            }
+
+        opener = self._get_digest_opener()
+        capabilities = self.getAutoTrackingCapabilities()
+        supported_modes = capabilities.get('supported_modes', ['motion'])
+
+        if normalized_mode == 'auto':
+            current_mode = 'motion'
+            config, _ = self._get_aoa_configuration(opener)
+            if config is not None:
+                current_mode = self._mode_from_aoa_configuration(config)
+            return {
+                'success': True,
+                'applied_mode': current_mode,
+                'fallback_applied': False,
+                'message': '%s; mode kept as auto' % toggle_result['message']
+            }
+
+        if normalized_mode not in supported_modes:
+            if 'motion' in supported_modes:
+                return {
+                    'success': True,
+                    'applied_mode': 'motion',
+                    'fallback_applied': True,
+                    'message': '%s; mode "%s" not supported by this device, fallback to motion'
+                               % (toggle_result['message'], normalized_mode)
+                }
+            return {
+                'success': False,
+                'applied_mode': 'motion',
+                'fallback_applied': False,
+                'message': '%s; mode "%s" not supported and motion fallback unavailable'
+                           % (toggle_result['message'], normalized_mode)
+            }
+
+        mode_success, mode_message = self._set_aoa_mode(opener, normalized_mode)
+        if normalized_mode == 'motion' and mode_success is None:
+            return {
+                'success': True,
+                'applied_mode': 'motion',
+                'fallback_applied': False,
+                'message': '%s; motion mode assumed because AOA is not available' % toggle_result['message']
+            }
+        if mode_success is True:
+            return {
+                'success': True,
+                'applied_mode': normalized_mode,
+                'fallback_applied': False,
+                'message': '%s; %s' % (toggle_result['message'], mode_message)
+            }
+
+        if normalized_mode != 'motion':
+            fallback_success, fallback_message = self._set_aoa_mode(opener, 'motion')
+            if fallback_success is True or fallback_success is None:
+                return {
+                    'success': True,
+                    'applied_mode': 'motion',
+                    'fallback_applied': True,
+                    'message': '%s; mode "%s" not supported (%s), fallback to motion (%s)'
+                               % (toggle_result['message'], normalized_mode, mode_message, fallback_message)
+                }
+
+        return {
+            'success': False,
+            'applied_mode': 'motion',
+            'fallback_applied': False,
+            'message': '%s; failed to apply mode "%s": %s' % (toggle_result['message'], normalized_mode, mode_message)
+        }
+
+    def getAutoTrackingCapabilities(self):
+        """
+        Returns supported modes and current autotracking status.
+        """
+        opener = self._get_digest_opener()
+
+        supported_modes = ['motion']
+        current_mode = 'motion'
+
+        capabilities, _ = self._get_aoa_configuration_capabilities(opener)
+        config, _ = self._get_aoa_configuration(opener)
+        if capabilities is not None:
+            supported_modes = self._extract_supported_modes_from_aoa_capabilities(capabilities)
+        if config is not None:
+            current_mode = self._mode_from_aoa_configuration(config)
+
+        state = self.getAutoTrackingState()
+        enabled = bool(state.get('enabled')) if state.get('enabled') is not None else False
+
+        return {
+            'success': True,
+            'supported_modes': supported_modes,
+            'current_mode': current_mode,
+            'enabled': enabled,
+            'message': state.get('message', '')
         }
 
     def getPTZState(self):

--- a/src/axis_camera/axis_lib/axis_control.py
+++ b/src/axis_camera/axis_lib/axis_control.py
@@ -18,6 +18,7 @@ except:
 import socket
 import math
 import xml.etree.ElementTree as ET
+import json
 
 class ControlAxis():
     def __init__(self, hostname, username='root', password=''):
@@ -619,38 +620,220 @@ class ControlAxis():
             conn.close()
         return ret
 
+    def _try_autotracking_vapix(self, opener, enable):
+        """
+        Tries to set autotracking via official VAPIX PTZ Autotracking API.
+        Available on cameras with firmware >= 10.x that expose the CGI natively.
+        Returns (success, message) tuple. success=None means 404 => try fallback.
+        """
+        url = 'http://%s/axis-cgi/ptz-autotracking/operator.cgi' % self.hostname
+        payload = {
+            'apiVersion': '1.0',
+            'method': 'setAutotrackingState',
+            'params': {'enabled': bool(enable)}
+        }
+        try:
+            request = urllib_request.Request(
+                url,
+                data=json.dumps(payload).encode('utf-8'),
+                headers={'Content-Type': 'application/json'}
+            )
+            response = opener.open(request, timeout=5)
+            body = response.read().decode('utf-8', errors='replace').strip()
+            if response.getcode() in (200, 204):
+                if body:
+                    try:
+                        body_json = json.loads(body)
+                    except Exception:
+                        body_json = None
+                    if isinstance(body_json, dict) and isinstance(body_json.get('error'), dict):
+                        return False, 'VAPIX operator.cgi error: %s' % str(body_json['error'].get('code'))
+                return True, 'Auto-tracking %s via VAPIX operator.cgi' % ('enabled' if enable else 'disabled')
+            return False, 'VAPIX operator.cgi HTTP %d' % response.getcode()
+        except urllib_error.HTTPError as e:
+            if e.code == 404:
+                return None, 'VAPIX operator.cgi not found (404)'  # None = try fallback
+            return False, 'VAPIX operator.cgi HTTP error %d: %s' % (e.code, e.reason)
+        except (urllib_error.URLError, socket.timeout) as e:
+            return False, 'VAPIX operator.cgi connection error: %s' % str(e)
+
+    def _try_autotracking_acap(self, opener, enable):
+        """
+        Tries to set autotracking via the PTZ Autotracker ACAP app local endpoint.
+        This is the API the app exposes regardless of firmware version, and is the
+        same endpoint used by the camera web UI. Works on cameras like P5676-LE.
+        Returns (success, message) tuple.
+        """
+        url = 'http://%s/local/axis-ptz-autotracking/settings.fcgi' % self.hostname
+        payload = {
+            'apiVersion': '1.0',
+            'method': 'setAutotrackingState',
+            'params': {'enabled': bool(enable)}
+        }
+        try:
+            request = urllib_request.Request(
+                url,
+                data=json.dumps(payload).encode('utf-8'),
+                headers={'Content-Type': 'application/json'}
+            )
+            response = opener.open(request, timeout=5)
+            body = response.read().decode('utf-8', errors='replace').strip()
+            if response.getcode() in (200, 204):
+                if body:
+                    try:
+                        body_json = json.loads(body)
+                    except Exception:
+                        body_json = None
+                    if isinstance(body_json, dict) and isinstance(body_json.get('error'), dict):
+                        return False, 'ACAP settings.fcgi error: %s' % str(body_json['error'].get('code'))
+                return True, 'Auto-tracking %s via ACAP settings.fcgi' % ('enabled' if enable else 'disabled')
+            return False, 'ACAP settings.fcgi HTTP %d' % response.getcode()
+        except urllib_error.HTTPError as e:
+            if e.code == 404:
+                return False, 'ACAP settings.fcgi not found (404) - PTZ Autotracker app may not be installed'
+            return False, 'ACAP settings.fcgi HTTP error %d: %s' % (e.code, e.reason)
+        except (urllib_error.URLError, socket.timeout) as e:
+            return False, 'ACAP settings.fcgi connection error: %s' % str(e)
+
     def setAutoTracking(self, enable):
         """
-        Enables or disables auto-tracking via VAPIX.
+        Enables or disables auto-tracking on Axis PTZ cameras.
+
+        Uses a two-tier approach to support a wide range of camera models:
+          1. VAPIX PTZ Autotracking API (/axis-cgi/ptz-autotracking/operator.cgi)
+             - Official Axis API, available on cameras with firmware >= 10.x
+          2. PTZ Autotracker ACAP app local API (/local/axis-ptz-autotracking/settings.fcgi)
+             - The app's own REST endpoint, used by the web UI, available on any
+               camera with the PTZ Autotracker ACAP app installed (e.g. P5676-LE)
+
         Returns a dict with keys: success (bool), message (str).
-        HTTP 204 => success; HTTP 400 => not supported by this model.
         """
         ret = {'success': False, 'message': ''}
-        conn = httplib.HTTPConnection(self.hostname)
-        value = 'on' if enable else 'off'
-        url = '/axis-cgi/com/ptz.cgi?autotrack=%s&camera=1' % value
-        try:
-            conn.request("GET", url)
-            response = conn.getresponse()
-            response.read()  # drain body
-            if response.status == 204:
-                ret['success'] = True
-                ret['message'] = 'Auto-tracking %s' % ('enabled' if enable else 'disabled')
-            elif response.status == 400:
-                ret['success'] = False
-                ret['message'] = 'Auto-tracking not supported by this camera model (HTTP 400)'
-            else:
-                ret['success'] = False
-                ret['message'] = 'Unexpected HTTP status %d while setting auto-tracking' % response.status
-        except socket.error as e:
-            ret['success'] = False
-            ret['message'] = 'Connection error: %s' % str(e)
-        except socket.timeout as e:
-            ret['success'] = False
-            ret['message'] = 'Connection timeout: %s' % str(e)
-        finally:
-            conn.close()
+        opener = self._get_digest_opener()
+
+        # 1. Try official VAPIX endpoint first
+        success, message = self._try_autotracking_vapix(opener, enable)
+        if success is True:
+            ret['success'] = True
+            ret['message'] = message
+            return ret
+        if success is False:
+            ret['message'] = message
+            return ret
+
+        # success is None => 404, fall through to ACAP app endpoint
+        # 2. Fall back to ACAP app local endpoint
+        success, message = self._try_autotracking_acap(opener, enable)
+        ret['success'] = success
+        ret['message'] = message
         return ret
+
+    def _extract_autotracking_enabled(self, payload):
+        """
+        Extracts autotracking enabled state from different JSON response shapes.
+        Returns True/False when found, otherwise None.
+        """
+        if isinstance(payload, bool):
+            return payload
+
+        if not isinstance(payload, dict):
+            return None
+
+        # Fast path for common direct keys
+        for key in ('enabled', 'active', 'autotracking', 'autotrack'):
+            value = payload.get(key)
+            if isinstance(value, bool):
+                return value
+
+        # Recursive walk for nested structures (data/result/params/etc.)
+        stack = [payload]
+        while stack:
+            current = stack.pop()
+            if not isinstance(current, dict):
+                continue
+
+            for key, value in current.items():
+                if key in ('enabled', 'active', 'autotracking', 'autotrack'):
+                    if isinstance(value, bool):
+                        return value
+                    if isinstance(value, str):
+                        lowered = value.strip().lower()
+                        if lowered in ('1', 'true', 'on', 'enabled', 'yes'):
+                            return True
+                        if lowered in ('0', 'false', 'off', 'disabled', 'no'):
+                            return False
+                if isinstance(value, dict):
+                    stack.append(value)
+
+        return None
+
+    def _read_autotracking_state_endpoint(self, opener, url):
+        """
+        Reads autotracking state from one endpoint trying common getter methods.
+        Returns (success, enabled, message).
+        """
+        methods = ('getAutotrackingState', 'getAutotrackerState', 'getState')
+        for method in methods:
+            payload = {
+                'apiVersion': '1.0',
+                'method': method,
+                'params': {}
+            }
+            try:
+                request = urllib_request.Request(
+                    url,
+                    data=json.dumps(payload).encode('utf-8'),
+                    headers={'Content-Type': 'application/json'}
+                )
+                response = opener.open(request, timeout=5)
+                body = response.read().decode('utf-8', errors='replace').strip()
+                if response.getcode() not in (200, 204):
+                    continue
+                if not body:
+                    continue
+
+                try:
+                    body_json = json.loads(body)
+                except Exception:
+                    continue
+
+                if isinstance(body_json, dict) and isinstance(body_json.get('error'), dict):
+                    continue
+
+                enabled = self._extract_autotracking_enabled(body_json)
+                if enabled is not None:
+                    return True, enabled, 'read via %s' % url
+            except urllib_error.HTTPError as e:
+                if e.code == 404:
+                    return False, None, '%s not found (404)' % url
+            except (urllib_error.URLError, socket.timeout) as e:
+                return False, None, 'connection error on %s: %s' % (url, str(e))
+
+        return False, None, 'no readable state on %s' % url
+
+    def getAutoTrackingState(self):
+        """
+        Reads current autotracking state from camera APIs.
+        Returns a dict: success (bool), enabled (bool or None), message (str).
+        """
+        opener = self._get_digest_opener()
+        urls = (
+            'http://%s/axis-cgi/ptz-autotracking/operator.cgi' % self.hostname,
+            'http://%s/local/axis-ptz-autotracking/settings.fcgi' % self.hostname,
+        )
+
+        errors = []
+        for url in urls:
+            success, enabled, message = self._read_autotracking_state_endpoint(opener, url)
+            if success:
+                return {'success': True, 'enabled': enabled, 'message': message}
+            errors.append(message)
+
+        return {
+            'success': False,
+            'enabled': None,
+            'message': '; '.join(errors)
+        }
 
     def getPTZState(self):
         """

--- a/src/axis_camera/axis_ptz_node.py
+++ b/src/axis_camera/axis_ptz_node.py
@@ -53,6 +53,7 @@ import diagnostic_msgs
 
 from axis_camera.axis_lib.axis_control import ControlAxis
 from axis_camera.axis_lib.device_info import get_device_info_with_fallback
+from axis_camera.msg import AxisMetadataDetectionArray
 from robotnik_msgs.srv import SetInt16, SetInt16Response
 from robotnik_msgs.srv import SetString, SetStringResponse
 from robotnik_msgs.srv import GetStringList, GetStringListResponse
@@ -143,6 +144,19 @@ class AxisPTZ(threading.Thread):
         self.autotracking_active_mode = 'motion'
         self.autotracking_supported_modes = ['motion']
         self.autotracking_fallback_applied = False
+
+        # Software auto-tracking state (person / vehicle class filtering)
+        self.autotracking_sw_active = False
+        self.sw_tracking_filter_class = 'all'
+        self.sw_tracking_gain_pan = args.get('sw_tracking_gain_pan', 0.5)
+        self.sw_tracking_gain_tilt = args.get('sw_tracking_gain_tilt', 0.5)
+        self.sw_tracking_timeout = args.get('sw_tracking_timeout', 2.0)
+        self.sw_tracking_min_interval = args.get('sw_tracking_min_interval', 0.1)
+        self.sw_tracking_last_detection = rospy.Time(0)
+        self.sw_tracking_last_cmd_time = rospy.Time(0)
+        # Param name in the detection node to keep filter_class in sync with autotracking mode
+        self.sw_detection_filter_param = args.get('sw_detection_filter_param', 'axis_camera_detection/filter_class')
+        rospy.set_param('~sw_detection_filter_param', self.sw_detection_filter_param)
 
         # Detect effective focus range at runtime
         self.effective_focus_min_raw = None
@@ -275,6 +289,8 @@ class AxisPTZ(threading.Thread):
         ns = rospy.get_namespace()
         self.pub = rospy.Publisher("~camera_params", AxisMsg, queue_size=10)
         self.sub = rospy.Subscriber("~ptz_command", ptz, self.commandPTZCb)
+        sw_tracking_topic = rospy.get_param('~sw_tracking_detection_topic', 'axis_camera_detection/metadata_filtered')
+        self.sw_tracking_sub = rospy.Subscriber(sw_tracking_topic, AxisMetadataDetectionArray, self._swTrackingDetectionCb)
         # Publish the joint state of the pan & tilt
         self.joint_state_publisher = rospy.Publisher(self.joint_states_topic, JointState, queue_size=10)
         # Publish camera zoom info
@@ -350,22 +366,114 @@ class AxisPTZ(threading.Thread):
 
     def setAutoTrackingServiceCb(self, req):
         response = SetAutoTrackingResponse()
-        result = self.controller.setAutoTrackingWithMode(req.enabled, req.mode)
-        response.success = result['success']
-        response.applied_mode = result.get('applied_mode', 'motion')
-        response.fallback_applied = result.get('fallback_applied', False)
-        response.message = result['message']
-        if result['success']:
-            self.autotracking_active = req.enabled
+        normalized_mode = self.controller._normalize_tracking_mode(req.mode)
+        sw_modes = ('person', 'vehicle')
+        use_sw_tracking = req.enabled and normalized_mode in sw_modes
+
+        if use_sw_tracking:
+            # Disable native autotracking (in case it was on) then activate sw tracking
+            if self.autotracking_active and not self.autotracking_sw_active:
+                self.controller.setAutoTracking(False)
+            self.autotracking_sw_active = True
+            self.sw_tracking_filter_class = 'human' if normalized_mode == 'person' else 'vehicle'
+            self.sw_tracking_last_detection = rospy.Time(0)
+            response.success = True
+            response.applied_mode = normalized_mode
+            response.fallback_applied = False
+            response.message = 'software tracking enabled for class=%s' % self.sw_tracking_filter_class
+            self.autotracking_active = True
             self.autotracking_requested_mode = req.mode
-            self.autotracking_active_mode = response.applied_mode
-            self.autotracking_fallback_applied = response.fallback_applied
-            self.autotracking_pub.publish(Bool(data=self.autotracking_active))
+            self.autotracking_active_mode = normalized_mode
+            self.autotracking_fallback_applied = False
+            self.autotracking_pub.publish(Bool(data=True))
             self._publishAutoTrackingStatus()
-            rospy.loginfo('%s:setAutoTrackingServiceCb: %s', rospy.get_name(), result['message'])
+            self._syncDetectionFilterClass(normalized_mode)
+            rospy.loginfo('%s:setAutoTrackingServiceCb: %s', rospy.get_name(), response.message)
         else:
-            rospy.logerr('%s:setAutoTrackingServiceCb: %s', rospy.get_name(), result['message'])
+            # Disabling or native mode: stop sw tracking first if active
+            if self.autotracking_sw_active:
+                self.autotracking_sw_active = False
+            result = self.controller.setAutoTrackingWithMode(req.enabled, req.mode)
+            response.success = result['success']
+            response.applied_mode = result.get('applied_mode', 'motion')
+            response.fallback_applied = result.get('fallback_applied', False)
+            response.message = result['message']
+            if result['success']:
+                self.autotracking_active = req.enabled
+                self.autotracking_requested_mode = req.mode
+                self.autotracking_active_mode = response.applied_mode
+                self.autotracking_fallback_applied = response.fallback_applied
+                self.autotracking_pub.publish(Bool(data=self.autotracking_active))
+                self._publishAutoTrackingStatus()
+                self._syncDetectionFilterClass(normalized_mode)
+                rospy.loginfo('%s:setAutoTrackingServiceCb: %s', rospy.get_name(), result['message'])
+            else:
+                rospy.logerr('%s:setAutoTrackingServiceCb: %s', rospy.get_name(), result['message'])
         return response
+
+    def _syncDetectionFilterClass(self, mode):
+        """Keeps the detection node filter_class in sync with the autotracking mode."""
+        mode_to_filter = {
+            'person': 'human',
+            'vehicle': 'vehicle',
+        }
+        filter_class = mode_to_filter.get(mode, 'all')
+        # Allow changing destination param at runtime via rosparam set.
+        target_param = rospy.get_param('~sw_detection_filter_param', self.sw_detection_filter_param)
+        self.sw_detection_filter_param = target_param
+        try:
+            rospy.set_param(target_param, filter_class)
+            rospy.loginfo('%s:_syncDetectionFilterClass: set %s=%s',
+                          rospy.get_name(), target_param, filter_class)
+        except Exception as exc:
+            rospy.logwarn('%s:_syncDetectionFilterClass: could not set param %s: %s',
+                          rospy.get_name(), target_param, exc)
+
+    def _swTrackingDetectionCb(self, msg):
+        """Callback from metadata_filtered: drives pan/tilt to center the best detection."""
+        if not self.autotracking_sw_active:
+            return
+        if not self.ptz_syncronized:
+            return
+
+        now = rospy.Time.now()
+
+        # Rate-limit commands
+        if (now - self.sw_tracking_last_cmd_time).to_sec() < self.sw_tracking_min_interval:
+            return
+
+        candidates = [d for d in msg.detections if d.class_label == self.sw_tracking_filter_class]
+        if not candidates:
+            return
+
+        self.sw_tracking_last_detection = now
+
+        # Pick the detection with the largest bounding box area (most prominent target)
+        best = max(candidates, key=lambda d: (d.right - d.left) * (d.bottom - d.top))
+
+        cx = (best.left + best.right) / 2.0
+        cy = (best.top + best.bottom) / 2.0
+
+        # Error: positive = object is to the right / below center
+        error_x = cx - 0.5
+        error_y = cy - 0.5
+
+        # Incremental pan/tilt in radians
+        delta_pan = self.sw_tracking_gain_pan * error_x
+        delta_tilt = -self.sw_tracking_gain_tilt * error_y  # negative: object below -> tilt down
+
+        new_pan, new_tilt, _ = self.enforcePTZLimits(
+            self.desired_pan + delta_pan,
+            self.desired_tilt + delta_tilt,
+            self.desired_zoom,
+        )
+        self.desired_pan = new_pan
+        self.desired_tilt = new_tilt
+        self.t_last_command_time = now
+        self.sw_tracking_last_cmd_time = now
+        self.sendPTZCommand()
+        rospy.logdebug_throttle(1, '%s:_swTrackingDetectionCb: error_x=%.3f error_y=%.3f delta_pan=%.3f delta_tilt=%.3f',
+                                rospy.get_name(), error_x, error_y, delta_pan, delta_tilt)
 
     def getAutoTrackingCapabilitiesServiceCb(self, req):
         response = GetAutoTrackingCapabilitiesResponse()
@@ -1127,7 +1235,12 @@ def main():
         'pan_offset': 0.0,
         'tilt_offset': 0.0,
         'image_settings_pub_rate': 1.0,
-        'iris_two_step_control': False
+        'iris_two_step_control': False,
+        'sw_tracking_gain_pan': 0.5,
+        'sw_tracking_gain_tilt': 0.5,
+        'sw_tracking_timeout': 2.0,
+        'sw_tracking_min_interval': 0.1,
+        'sw_detection_filter_param': 'axis_camera_detection/filter_class'
     }
     args = {}
 

--- a/src/axis_camera/axis_ptz_node.py
+++ b/src/axis_camera/axis_ptz_node.py
@@ -288,6 +288,7 @@ class AxisPTZ(threading.Thread):
         self.get_white_balance_mode_service = rospy.Service('~get_white_balance_mode', GetStringList, self.getWhiteBalanceModeServiceCb)
         self.get_image_settings_service = rospy.Service('~get_image_settings', GetImageSettings, self.getImageSettingsServiceCb)
         self.autotracking_pub = rospy.Publisher('~autotracking_active', Bool, queue_size=10, latch=True)
+        self.autotracking_pub.publish(Bool(data=self.autotracking_active))
         self.set_autotracking_service = rospy.Service('~set_autotracking', SetAutoTracking, self.setAutoTrackingServiceCb)
         self.loadDeviceInfo()
         self.device_info_service = rospy.Service('~get_device_info', GetAxisDeviceInfo, self.getDeviceInfoServiceCb)
@@ -298,6 +299,8 @@ class AxisPTZ(threading.Thread):
         self.diagnostics_updater.add("Ptz state updater", self.getStateDiagnostic)
         # Creates a periodic callback to publish the diagnostics at desired freq
         self.diagnostics_timer = rospy.Timer(rospy.Duration(1.0), self.publishDiagnostics)
+        # Poll autotracking state to detect changes made outside ROS (web UI, VMS, etc.)
+        self.autotracking_poll_timer = rospy.Timer(rospy.Duration(2.0), self.pollAutoTrackingState)
 
         self.zoom_augments = []
         for i in range(int(self.min_zoom_augment), int(self.max_zoom_augment) + 1, int(self.min_zoom_step)):
@@ -343,6 +346,22 @@ class AxisPTZ(threading.Thread):
         else:
             rospy.logerr('%s:setAutoTrackingServiceCb: %s', rospy.get_name(), result['message'])
         return response
+
+    def pollAutoTrackingState(self, event):
+        """
+        Synchronizes autotracking state with camera in case it is changed externally.
+        """
+        result = self.controller.getAutoTrackingState()
+        if not result['success']:
+            rospy.logdebug_throttle(30, '%s:pollAutoTrackingState: %s', rospy.get_name(), result['message'])
+            return
+
+        camera_state = bool(result['enabled'])
+        if camera_state != self.autotracking_active:
+            self.autotracking_active = camera_state
+            self.autotracking_pub.publish(Bool(data=self.autotracking_active))
+            rospy.loginfo('%s:pollAutoTrackingState: autotracking updated from camera: %s',
+                          rospy.get_name(), self.autotracking_active)
 
     def commandPTZCb(self, msg):
         """
@@ -865,8 +884,6 @@ class AxisPTZ(threading.Thread):
         zoom_parameters.zoom_augments = self.zoom_augments
 
         self.zoom_parameter_pub.publish(zoom_parameters)
-        # Publishes the auto-tracking state
-        self.autotracking_pub.publish(Bool(data=self.autotracking_active))
         # Publishes the current PTZ values
         self.pub.publish(self.current_ptz)
         

--- a/src/axis_camera/axis_ptz_node.py
+++ b/src/axis_camera/axis_ptz_node.py
@@ -53,7 +53,6 @@ import diagnostic_msgs
 
 from axis_camera.axis_lib.axis_control import ControlAxis
 from axis_camera.axis_lib.device_info import get_device_info_with_fallback
-from axis_camera.msg import AxisMetadataDetectionArray
 from robotnik_msgs.srv import SetInt16, SetInt16Response
 from robotnik_msgs.srv import SetString, SetStringResponse
 from robotnik_msgs.srv import GetStringList, GetStringListResponse
@@ -145,15 +144,6 @@ class AxisPTZ(threading.Thread):
         self.autotracking_supported_modes = ['motion']
         self.autotracking_fallback_applied = False
 
-        # Software auto-tracking state (person / vehicle class filtering)
-        self.autotracking_sw_active = False
-        self.sw_tracking_filter_class = 'all'
-        self.sw_tracking_gain_pan = args.get('sw_tracking_gain_pan', 0.5)
-        self.sw_tracking_gain_tilt = args.get('sw_tracking_gain_tilt', 0.5)
-        self.sw_tracking_timeout = args.get('sw_tracking_timeout', 2.0)
-        self.sw_tracking_min_interval = args.get('sw_tracking_min_interval', 0.1)
-        self.sw_tracking_last_detection = rospy.Time(0)
-        self.sw_tracking_last_cmd_time = rospy.Time(0)
         # Param name in the detection node to keep filter_class in sync with autotracking mode
         self.sw_detection_filter_param = args.get('sw_detection_filter_param', 'axis_camera_detection/filter_class')
         rospy.set_param('~sw_detection_filter_param', self.sw_detection_filter_param)
@@ -289,8 +279,6 @@ class AxisPTZ(threading.Thread):
         ns = rospy.get_namespace()
         self.pub = rospy.Publisher("~camera_params", AxisMsg, queue_size=10)
         self.sub = rospy.Subscriber("~ptz_command", ptz, self.commandPTZCb)
-        sw_tracking_topic = rospy.get_param('~sw_tracking_detection_topic', 'axis_camera_detection/metadata_filtered')
-        self.sw_tracking_sub = rospy.Subscriber(sw_tracking_topic, AxisMetadataDetectionArray, self._swTrackingDetectionCb)
         # Publish the joint state of the pan & tilt
         self.joint_state_publisher = rospy.Publisher(self.joint_states_topic, JointState, queue_size=10)
         # Publish camera zoom info
@@ -367,48 +355,22 @@ class AxisPTZ(threading.Thread):
     def setAutoTrackingServiceCb(self, req):
         response = SetAutoTrackingResponse()
         normalized_mode = self.controller._normalize_tracking_mode(req.mode)
-        sw_modes = ('person', 'vehicle')
-        use_sw_tracking = req.enabled and normalized_mode in sw_modes
-
-        if use_sw_tracking:
-            # Disable native autotracking (in case it was on) then activate sw tracking
-            if self.autotracking_active and not self.autotracking_sw_active:
-                self.controller.setAutoTracking(False)
-            self.autotracking_sw_active = True
-            self.sw_tracking_filter_class = 'human' if normalized_mode == 'person' else 'vehicle'
-            self.sw_tracking_last_detection = rospy.Time(0)
-            response.success = True
-            response.applied_mode = normalized_mode
-            response.fallback_applied = False
-            response.message = 'software tracking enabled for class=%s' % self.sw_tracking_filter_class
-            self.autotracking_active = True
+        result = self.controller.setAutoTrackingWithMode(req.enabled, req.mode)
+        response.success = result['success']
+        response.applied_mode = result.get('applied_mode', 'motion')
+        response.fallback_applied = result.get('fallback_applied', False)
+        response.message = result['message']
+        if result['success']:
+            self.autotracking_active = req.enabled
             self.autotracking_requested_mode = req.mode
-            self.autotracking_active_mode = normalized_mode
-            self.autotracking_fallback_applied = False
-            self.autotracking_pub.publish(Bool(data=True))
+            self.autotracking_active_mode = response.applied_mode
+            self.autotracking_fallback_applied = response.fallback_applied
+            self.autotracking_pub.publish(Bool(data=self.autotracking_active))
             self._publishAutoTrackingStatus()
             self._syncDetectionFilterClass(normalized_mode)
-            rospy.loginfo('%s:setAutoTrackingServiceCb: %s', rospy.get_name(), response.message)
+            rospy.loginfo('%s:setAutoTrackingServiceCb: %s', rospy.get_name(), result['message'])
         else:
-            # Disabling or native mode: stop sw tracking first if active
-            if self.autotracking_sw_active:
-                self.autotracking_sw_active = False
-            result = self.controller.setAutoTrackingWithMode(req.enabled, req.mode)
-            response.success = result['success']
-            response.applied_mode = result.get('applied_mode', 'motion')
-            response.fallback_applied = result.get('fallback_applied', False)
-            response.message = result['message']
-            if result['success']:
-                self.autotracking_active = req.enabled
-                self.autotracking_requested_mode = req.mode
-                self.autotracking_active_mode = response.applied_mode
-                self.autotracking_fallback_applied = response.fallback_applied
-                self.autotracking_pub.publish(Bool(data=self.autotracking_active))
-                self._publishAutoTrackingStatus()
-                self._syncDetectionFilterClass(normalized_mode)
-                rospy.loginfo('%s:setAutoTrackingServiceCb: %s', rospy.get_name(), result['message'])
-            else:
-                rospy.logerr('%s:setAutoTrackingServiceCb: %s', rospy.get_name(), result['message'])
+            rospy.logerr('%s:setAutoTrackingServiceCb: %s', rospy.get_name(), result['message'])
         return response
 
     def _syncDetectionFilterClass(self, mode):
@@ -428,52 +390,6 @@ class AxisPTZ(threading.Thread):
         except Exception as exc:
             rospy.logwarn('%s:_syncDetectionFilterClass: could not set param %s: %s',
                           rospy.get_name(), target_param, exc)
-
-    def _swTrackingDetectionCb(self, msg):
-        """Callback from metadata_filtered: drives pan/tilt to center the best detection."""
-        if not self.autotracking_sw_active:
-            return
-        if not self.ptz_syncronized:
-            return
-
-        now = rospy.Time.now()
-
-        # Rate-limit commands
-        if (now - self.sw_tracking_last_cmd_time).to_sec() < self.sw_tracking_min_interval:
-            return
-
-        candidates = [d for d in msg.detections if d.class_label == self.sw_tracking_filter_class]
-        if not candidates:
-            return
-
-        self.sw_tracking_last_detection = now
-
-        # Pick the detection with the largest bounding box area (most prominent target)
-        best = max(candidates, key=lambda d: (d.right - d.left) * (d.bottom - d.top))
-
-        cx = (best.left + best.right) / 2.0
-        cy = (best.top + best.bottom) / 2.0
-
-        # Error: positive = object is to the right / below center
-        error_x = cx - 0.5
-        error_y = cy - 0.5
-
-        # Incremental pan/tilt in radians
-        delta_pan = self.sw_tracking_gain_pan * error_x
-        delta_tilt = -self.sw_tracking_gain_tilt * error_y  # negative: object below -> tilt down
-
-        new_pan, new_tilt, _ = self.enforcePTZLimits(
-            self.desired_pan + delta_pan,
-            self.desired_tilt + delta_tilt,
-            self.desired_zoom,
-        )
-        self.desired_pan = new_pan
-        self.desired_tilt = new_tilt
-        self.t_last_command_time = now
-        self.sw_tracking_last_cmd_time = now
-        self.sendPTZCommand()
-        rospy.logdebug_throttle(1, '%s:_swTrackingDetectionCb: error_x=%.3f error_y=%.3f delta_pan=%.3f delta_tilt=%.3f',
-                                rospy.get_name(), error_x, error_y, delta_pan, delta_tilt)
 
     def getAutoTrackingCapabilitiesServiceCb(self, req):
         response = GetAutoTrackingCapabilitiesResponse()
@@ -1236,10 +1152,6 @@ def main():
         'tilt_offset': 0.0,
         'image_settings_pub_rate': 1.0,
         'iris_two_step_control': False,
-        'sw_tracking_gain_pan': 0.5,
-        'sw_tracking_gain_tilt': 0.5,
-        'sw_tracking_timeout': 2.0,
-        'sw_tracking_min_interval': 0.1,
         'sw_detection_filter_param': 'axis_camera_detection/filter_class'
     }
     args = {}

--- a/src/axis_camera/axis_ptz_node.py
+++ b/src/axis_camera/axis_ptz_node.py
@@ -58,6 +58,8 @@ from robotnik_msgs.srv import SetString, SetStringResponse
 from robotnik_msgs.srv import GetStringList, GetStringListResponse
 from robotnik_msgs.srv import GetImageSettings, GetImageSettingsResponse
 from robotnik_msgs.srv import SetAutoTracking, SetAutoTrackingResponse
+from robotnik_msgs.srv import GetAutoTrackingCapabilities, GetAutoTrackingCapabilitiesResponse
+from robotnik_msgs.msg import AutoTrackingStatus
 from std_msgs.msg import Bool
 
 class AxisPTZ(threading.Thread):
@@ -137,6 +139,10 @@ class AxisPTZ(threading.Thread):
 
         # Auto-tracking state
         self.autotracking_active = False
+        self.autotracking_requested_mode = 'auto'
+        self.autotracking_active_mode = 'motion'
+        self.autotracking_supported_modes = ['motion']
+        self.autotracking_fallback_applied = False
 
         # Detect effective focus range at runtime
         self.effective_focus_min_raw = None
@@ -288,9 +294,17 @@ class AxisPTZ(threading.Thread):
         self.get_white_balance_mode_service = rospy.Service('~get_white_balance_mode', GetStringList, self.getWhiteBalanceModeServiceCb)
         self.get_image_settings_service = rospy.Service('~get_image_settings', GetImageSettings, self.getImageSettingsServiceCb)
         self.autotracking_pub = rospy.Publisher('~autotracking_active', Bool, queue_size=10, latch=True)
+        self.autotracking_status_pub = rospy.Publisher('~autotracking_status', AutoTrackingStatus, queue_size=10, latch=True)
         self.autotracking_pub.publish(Bool(data=self.autotracking_active))
+        self._publishAutoTrackingStatus()
         self.set_autotracking_service = rospy.Service('~set_autotracking', SetAutoTracking, self.setAutoTrackingServiceCb)
+        self.get_autotracking_capabilities_service = rospy.Service(
+            '~get_autotracking_capabilities',
+            GetAutoTrackingCapabilities,
+            self.getAutoTrackingCapabilitiesServiceCb
+        )
         self.loadDeviceInfo()
+        self._loadAutoTrackingCapabilities()
         self.device_info_service = rospy.Service('~get_device_info', GetAxisDeviceInfo, self.getDeviceInfoServiceCb)
 
         # Diagnostic Updater
@@ -336,16 +350,52 @@ class AxisPTZ(threading.Thread):
 
     def setAutoTrackingServiceCb(self, req):
         response = SetAutoTrackingResponse()
-        result = self.controller.setAutoTracking(req.enable)
+        result = self.controller.setAutoTrackingWithMode(req.enabled, req.mode)
         response.success = result['success']
+        response.applied_mode = result.get('applied_mode', 'motion')
+        response.fallback_applied = result.get('fallback_applied', False)
         response.message = result['message']
         if result['success']:
-            self.autotracking_active = req.enable
+            self.autotracking_active = req.enabled
+            self.autotracking_requested_mode = req.mode
+            self.autotracking_active_mode = response.applied_mode
+            self.autotracking_fallback_applied = response.fallback_applied
             self.autotracking_pub.publish(Bool(data=self.autotracking_active))
+            self._publishAutoTrackingStatus()
             rospy.loginfo('%s:setAutoTrackingServiceCb: %s', rospy.get_name(), result['message'])
         else:
             rospy.logerr('%s:setAutoTrackingServiceCb: %s', rospy.get_name(), result['message'])
         return response
+
+    def getAutoTrackingCapabilitiesServiceCb(self, req):
+        response = GetAutoTrackingCapabilitiesResponse()
+        result = self.controller.getAutoTrackingCapabilities()
+        response.supported_modes = result.get('supported_modes', ['motion'])
+        response.current_mode = result.get('current_mode', 'motion')
+        response.enabled = bool(result.get('enabled', False))
+
+        # keep cached state aligned for status publication
+        self.autotracking_supported_modes = list(response.supported_modes)
+        self.autotracking_active_mode = response.current_mode
+        self.autotracking_active = response.enabled
+        self._publishAutoTrackingStatus()
+        return response
+
+    def _loadAutoTrackingCapabilities(self):
+        result = self.controller.getAutoTrackingCapabilities()
+        self.autotracking_supported_modes = result.get('supported_modes', ['motion'])
+        self.autotracking_active_mode = result.get('current_mode', 'motion')
+        self.autotracking_active = bool(result.get('enabled', False))
+        self.autotracking_pub.publish(Bool(data=self.autotracking_active))
+        self._publishAutoTrackingStatus()
+
+    def _publishAutoTrackingStatus(self):
+        msg = AutoTrackingStatus()
+        msg.enabled = self.autotracking_active
+        msg.requested_mode = self.autotracking_requested_mode
+        msg.active_mode = self.autotracking_active_mode
+        msg.fallback_applied = self.autotracking_fallback_applied
+        self.autotracking_status_pub.publish(msg)
 
     def pollAutoTrackingState(self, event):
         """
@@ -357,11 +407,17 @@ class AxisPTZ(threading.Thread):
             return
 
         camera_state = bool(result['enabled'])
-        if camera_state != self.autotracking_active:
+        caps = self.controller.getAutoTrackingCapabilities()
+        camera_mode = caps.get('current_mode', self.autotracking_active_mode)
+        self.autotracking_supported_modes = caps.get('supported_modes', self.autotracking_supported_modes)
+
+        if camera_state != self.autotracking_active or camera_mode != self.autotracking_active_mode:
             self.autotracking_active = camera_state
+            self.autotracking_active_mode = camera_mode
             self.autotracking_pub.publish(Bool(data=self.autotracking_active))
-            rospy.loginfo('%s:pollAutoTrackingState: autotracking updated from camera: %s',
-                          rospy.get_name(), self.autotracking_active)
+            self._publishAutoTrackingStatus()
+            rospy.loginfo('%s:pollAutoTrackingState: autotracking updated from camera: enabled=%s mode=%s',
+                          rospy.get_name(), self.autotracking_active, self.autotracking_active_mode)
 
     def commandPTZCb(self, msg):
         """

--- a/src/axis_camera/axis_ptz_node.py
+++ b/src/axis_camera/axis_ptz_node.py
@@ -57,6 +57,8 @@ from robotnik_msgs.srv import SetInt16, SetInt16Response
 from robotnik_msgs.srv import SetString, SetStringResponse
 from robotnik_msgs.srv import GetStringList, GetStringListResponse
 from robotnik_msgs.srv import GetImageSettings, GetImageSettingsResponse
+from robotnik_msgs.srv import SetAutoTracking, SetAutoTrackingResponse
+from std_msgs.msg import Bool
 
 class AxisPTZ(threading.Thread):
     """
@@ -132,6 +134,9 @@ class AxisPTZ(threading.Thread):
         self.iris_min_value = 1.0
         self.iris_max_value = 9999.0
         self.iris_two_step_control = args.get('iris_two_step_control', False)
+
+        # Auto-tracking state
+        self.autotracking_active = False
 
         # Detect effective focus range at runtime
         self.effective_focus_min_raw = None
@@ -282,6 +287,8 @@ class AxisPTZ(threading.Thread):
         self.set_white_balance_service = rospy.Service('~set_white_balance', SetString, self.setWhiteBalanceServiceCb)
         self.get_white_balance_mode_service = rospy.Service('~get_white_balance_mode', GetStringList, self.getWhiteBalanceModeServiceCb)
         self.get_image_settings_service = rospy.Service('~get_image_settings', GetImageSettings, self.getImageSettingsServiceCb)
+        self.autotracking_pub = rospy.Publisher('~autotracking_active', Bool, queue_size=10, latch=True)
+        self.set_autotracking_service = rospy.Service('~set_autotracking', SetAutoTracking, self.setAutoTrackingServiceCb)
         self.loadDeviceInfo()
         self.device_info_service = rospy.Service('~get_device_info', GetAxisDeviceInfo, self.getDeviceInfoServiceCb)
 
@@ -324,11 +331,28 @@ class AxisPTZ(threading.Thread):
             firmware=self.device_firmware
         )
 
+    def setAutoTrackingServiceCb(self, req):
+        response = SetAutoTrackingResponse()
+        result = self.controller.setAutoTracking(req.enable)
+        response.success = result['success']
+        response.message = result['message']
+        if result['success']:
+            self.autotracking_active = req.enable
+            self.autotracking_pub.publish(Bool(data=self.autotracking_active))
+            rospy.loginfo('%s:setAutoTrackingServiceCb: %s', rospy.get_name(), result['message'])
+        else:
+            rospy.logerr('%s:setAutoTrackingServiceCb: %s', rospy.get_name(), result['message'])
+        return response
+
     def commandPTZCb(self, msg):
         """
             Command for ptz movements
         """
         self.t_last_command_time = rospy.Time.now()
+
+        if self.autotracking_active:
+            rospy.logwarn_throttle(5, '%s:commandPTZCb: ignoring PTZ command, auto-tracking is active', rospy.get_name())
+            return
 
         if self.ptz_syncronized:
             self.setCommandPTZ(msg)
@@ -658,6 +682,9 @@ class AxisPTZ(threading.Thread):
         """
         t_now = rospy.Time.now()
 
+        if self.autotracking_active:
+            return
+
         if self.control_mode == 'position':
             # Only if it's syncronized
             if self.ptz_syncronized:
@@ -838,6 +865,8 @@ class AxisPTZ(threading.Thread):
         zoom_parameters.zoom_augments = self.zoom_augments
 
         self.zoom_parameter_pub.publish(zoom_parameters)
+        # Publishes the auto-tracking state
+        self.autotracking_pub.publish(Bool(data=self.autotracking_active))
         # Publishes the current PTZ values
         self.pub.publish(self.current_ptz)
         


### PR DESCRIPTION
# Feat/autotracking mode selection
feat: sync detection filter_class with set_autotracking mode and document status/param validation

## Summary
This PR keeps PTZ autotracking mode and detection filtering aligned.

On every successful call to set_autotracking, the PTZ node now updates the detection filter class based on the requested mode, including when enabled is false.
It also supports runtime destination changes through detection_filter_param and ensures startup visibility of key params.

## What changed
PTZ service callback now syncs detection filter class on success for all enabled/disabled cases.
Mode mapping for detection filter:
person / human -> human
vehicle / car -> vehicle
motion / auto / unknown -> all
Runtime hot-reload of destination param:
detection_filter_param is re-read on each sync call.
PTZ publishes detection_filter_param at startup so it is visible via rosparam get.
Detection node publishes filter_class at startup so it exists immediately.

## AOA note
When mode is person or vehicle, the existing autotracking flow also applies AOA class configuration (control.cgi path) as implemented in axis_control.  
This PR does not change AOA behavior; it keeps detection filter_class synchronized with the same mode selection.

## Backward compatibility
- Service API unchanged.
- Existing launch files keep working because defaults are provided.
- If detection node is absent, param updates still succeed in the ROS Parameter Server and do not break service flow.

## How to test

### 1) Launch
```bash
roslaunch axis_camera axis_ptz.launch
```

### 2) Verify startup params exist
```bash
rosparam get /axis_camera_ptz/detection_filter_param
# Expected: axis_camera_detection/filter_class

rosparam get /axis_camera_detection/filter_class
# Expected: all
```

### 3) Verify mode-to-filter sync
```bash
rosservice call /axis_camera_ptz/set_autotracking "enabled: true
mode: 'person'"
rosparam get /axis_camera_detection/filter_class
# Expected: human
```

```bash
rosservice call /axis_camera_ptz/set_autotracking "enabled: true
mode: 'vehicle'"
rosparam get /axis_camera_detection/filter_class
# Expected: vehicle
```

```bash
rosservice call /axis_camera_ptz/set_autotracking "enabled: true
mode: 'motion'"
rosparam get /axis_camera_detection/filter_class
# Expected: all
```

### 4) Verify behavior when enabled is false
```bash
rosservice call /axis_camera_ptz/set_autotracking "enabled: false
mode: 'vehicle'"
rosparam get /axis_camera_detection/filter_class
# Expected: vehicle
```

```bash
rosservice call /axis_camera_ptz/set_autotracking "enabled: false
mode: 'person'"
rosparam get /axis_camera_detection/filter_class
# Expected: human
```

### 5) Verify status topic
```bash
rostopic echo /axis_camera_ptz/autotracking_status
```

### 6) Runtime destination change (multi-camera scenario)
```bash
rosparam set /axis_camera_ptz/detection_filter_param axis_camera_2_detection/filter_class
rosservice call /axis_camera_ptz/set_autotracking "enabled: true
mode: 'person'"
rosparam get /axis_camera_2_detection/filter_class
# Expected: human
```

Restore default:
```bash
rosparam set /axis_camera_ptz/detection_filter_param axis_camera_detection/filter_class
```

### 7) Verify capabilities reflect available modes:
```bash
rosservice call /axis_camera_ptz/get_autotracking_capabilities
```

### 8) Live filtered detections check
```bash
rostopic echo /axis_camera_detection/metadata_filtered
```