### PR TITLE
Feat/new auth endpoints and get_day_night_mode service

### DIFF
--- a/src/axis_camera/axis_lib/axis_control.py
+++ b/src/axis_camera/axis_lib/axis_control.py
@@ -928,6 +928,54 @@ class ControlAxis():
             'modes': modes
         }
 
+    def getDayNightModes(self):
+        parameter_path, error_message = self._get_day_night_parameter_path()
+        if parameter_path is None:
+            return {
+                'success': False,
+                'message': error_message,
+                'modes': []
+            }
+
+        enum_modes = None
+        parts = parameter_path.rsplit('.', 1)
+        if len(parts) == 2:
+            enum_modes = self._get_parameter_enum_values_from_definitions(parts[0], parts[1])
+
+        supported_modes, error_message = self._get_supported_day_night_modes(parameter_path)
+        if supported_modes is None:
+            return {
+                'success': False,
+                'message': error_message,
+                'modes': []
+            }
+
+        # Normalize and present user-friendly aliases.
+        source_modes = set(m.lower() for m in enum_modes) if enum_modes else set(m.lower() for m in supported_modes)
+
+        # Map firmware boolean-style modes to friendly canonical names.
+        canonical = set()
+        for m in source_modes:
+            if m == 'yes':
+                canonical.add('day')
+            elif m == 'no':
+                canonical.add('night')
+            else:
+                canonical.add(m)
+
+        # Preferred ordering: auto, day, night
+        preferred = ['auto', 'day', 'night']
+        ordered = [p for p in preferred if p in canonical]
+        # Append any remaining modes sorted for determinism
+        remaining = sorted(canonical.difference(ordered))
+        modes = ordered + remaining
+
+        return {
+            'success': True,
+            'message': 'day_night modes retrieved',
+            'modes': modes
+        }
+
     def setWhiteBalance(self, white_balance):
         white_balance = white_balance.strip()
         if not white_balance:

--- a/src/axis_camera/axis_lib/axis_control.py
+++ b/src/axis_camera/axis_lib/axis_control.py
@@ -26,9 +26,9 @@ class ControlAxis():
         self._password = password
         self._sensor_parameter_names = None
         self._white_balance_parameter_path = None
-        self._white_balance_supported_modes = None
+        self._white_balance_supported_modes = {}
         self._day_night_parameter_path = None
-        self._day_night_supported_modes = None
+        self._day_night_supported_modes = {}
         self._parameter_int_ranges = {}
         self._parameter_enum_values = {}
         self._last_known_image_settings = {
@@ -52,9 +52,20 @@ class ControlAxis():
                 'listformat': 'xmlschema',
                 'group': group
             })
-            url = 'http://%s/axis-cgi/admin/param.cgi?%s' % (self.hostname, params)
-            response = opener.open(url, timeout=5)
-            xml_text = response.read().decode('utf-8', errors='replace')
+            xml_text = None
+            for cgi_path in ('/axis-cgi/admin/param.cgi', '/axis-cgi/param.cgi'):
+                try:
+                    url = 'http://%s%s?%s' % (self.hostname, cgi_path, params)
+                    response = opener.open(url, timeout=5)
+                    candidate = response.read().decode('utf-8', errors='replace')
+                    if candidate and not candidate.lstrip().startswith('# Error'):
+                        xml_text = candidate
+                        break
+                except Exception:
+                    continue
+            if xml_text is None:
+                self._parameter_int_ranges[cache_key] = (None, None)
+                return (None, None)
             root = ET.fromstring(xml_text)
             ns = {'ax': 'http://www.axis.com/ParameterDefinitionsSchema'}
 
@@ -94,9 +105,20 @@ class ControlAxis():
                 'listformat': 'xmlschema',
                 'group': group
             })
-            url = 'http://%s/axis-cgi/admin/param.cgi?%s' % (self.hostname, params)
-            response = opener.open(url, timeout=5)
-            xml_text = response.read().decode('utf-8', errors='replace')
+            xml_text = None
+            for cgi_path in ('/axis-cgi/admin/param.cgi', '/axis-cgi/param.cgi'):
+                try:
+                    url = 'http://%s%s?%s' % (self.hostname, cgi_path, params)
+                    response = opener.open(url, timeout=5)
+                    candidate = response.read().decode('utf-8', errors='replace')
+                    if candidate and not candidate.lstrip().startswith('# Error'):
+                        xml_text = candidate
+                        break
+                except Exception:
+                    continue
+            if xml_text is None:
+                self._parameter_enum_values[cache_key] = None
+                return None
             root = ET.fromstring(xml_text)
             ns = {'ax': 'http://www.axis.com/ParameterDefinitionsSchema'}
 
@@ -178,9 +200,19 @@ class ControlAxis():
             'action': 'list',
             'group': 'ImageSource.I0.Sensor'
         })
-        url = 'http://%s/axis-cgi/admin/param.cgi?%s' % (self.hostname, params)
-        response = opener.open(url, timeout=5)
-        body = response.read().decode('utf-8').splitlines()
+        body = None
+        for cgi_path in ('/axis-cgi/admin/param.cgi', '/axis-cgi/param.cgi'):
+            try:
+                url = 'http://%s%s?%s' % (self.hostname, cgi_path, params)
+                response = opener.open(url, timeout=5)
+                lines = response.read().decode('utf-8').splitlines()
+                if lines and not lines[0].startswith('# Error'):
+                    body = lines
+                    break
+            except Exception:
+                continue
+        if body is None:
+            body = []
 
         parameter_names = set()
         for line in body:
@@ -293,9 +325,20 @@ class ControlAxis():
             'action': 'list',
             'group': group
         })
-        url = 'http://%s/axis-cgi/admin/param.cgi?%s' % (self.hostname, params)
-        response = opener.open(url, timeout=5)
-        return response.read().decode('utf-8').splitlines()
+        last_exc = None
+        for cgi_path in ('/axis-cgi/admin/param.cgi', '/axis-cgi/param.cgi'):
+            try:
+                url = 'http://%s%s?%s' % (self.hostname, cgi_path, params)
+                response = opener.open(url, timeout=5)
+                lines = response.read().decode('utf-8').splitlines()
+                if not lines or not lines[0].startswith('# Error'):
+                    return lines
+            except Exception as e:
+                last_exc = e
+                continue
+        if last_exc is not None:
+            raise last_exc
+        return []
 
     def _group_exists(self, group):
         try:
@@ -313,26 +356,24 @@ class ControlAxis():
         return True
 
     def _read_parameter_value(self, parameter_path):
-        """Read a single parameter value from VAPIX. Returns the value or None if not found."""
         try:
             opener = self._get_digest_opener()
             params = urllib_parse.urlencode({
                 'action': 'list',
                 'group': parameter_path
             })
-            url = 'http://%s/axis-cgi/admin/param.cgi?%s' % (self.hostname, params)
-            response = opener.open(url, timeout=5)
-            body = response.read().decode('utf-8').strip()
-            
-            if not body or body.startswith('# Error'):
-                return None
-            
-            # If returns a single line with the parameter
-            lines = body.splitlines()
-            for line in lines:
-                if '=' in line and not line.startswith('#'):
-                    value = line.split('=', 1)[1].strip()
-                    return value
+            for cgi_path in ('/axis-cgi/admin/param.cgi', '/axis-cgi/param.cgi'):
+                try:
+                    url = 'http://%s%s?%s' % (self.hostname, cgi_path, params)
+                    response = opener.open(url, timeout=5)
+                    body = response.read().decode('utf-8').strip()
+                    if not body or body.startswith('# Error'):
+                        continue
+                    for line in body.splitlines():
+                        if '=' in line and not line.startswith('#'):
+                            return line.split('=', 1)[1].strip()
+                except Exception:
+                    continue
             return None
         except Exception:
             return None
@@ -400,52 +441,63 @@ class ControlAxis():
         if self._day_night_parameter_path is not None:
             return self._day_night_parameter_path, ''
 
-        # Try the parameter specified in the VAPIX task first
-        if self._group_exists('ImageSource.I0.DayNight.DayNightShift'):
+        # Prefer IrCutFilter when readable; this is the endpoint used by many modern firmwares.
+        ir_cut_value = self._read_parameter_value('ImageSource.I0.DayNight.IrCutFilter')
+        if ir_cut_value is not None:
+            self._day_night_parameter_path = 'ImageSource.I0.DayNight.IrCutFilter'
+            return self._day_night_parameter_path, ''
+
+        # Fall back to DayNightShift if available.
+        day_night_shift_value = self._read_parameter_value('ImageSource.I0.DayNight.DayNightShift')
+        if day_night_shift_value is not None:
             self._day_night_parameter_path = 'ImageSource.I0.DayNight.DayNightShift'
             return self._day_night_parameter_path, ''
 
-        # Fall back to IrCutFilter (used on some firmware versions)
+        # Last-resort checks when reads are unavailable.
         if self._group_exists('ImageSource.I0.DayNight.IrCutFilter'):
             self._day_night_parameter_path = 'ImageSource.I0.DayNight.IrCutFilter'
+            return self._day_night_parameter_path, ''
+
+        if self._group_exists('ImageSource.I0.DayNight.DayNightShift'):
+            self._day_night_parameter_path = 'ImageSource.I0.DayNight.DayNightShift'
             return self._day_night_parameter_path, ''
 
         return None, 'camera does not expose a supported day/night parameter'
 
     def _get_supported_white_balance_modes(self, parameter_path):
-        if self._white_balance_supported_modes is not None:
-            return self._white_balance_supported_modes, ''
+        if parameter_path in self._white_balance_supported_modes:
+            return self._white_balance_supported_modes[parameter_path], ''
 
         parts = parameter_path.rsplit('.', 1)
         if len(parts) == 2:
             group, parameter_name = parts
             modes = self._get_parameter_enum_values_from_definitions(group, parameter_name)
             if modes:
-                self._white_balance_supported_modes = modes
-                return self._white_balance_supported_modes, ''
+                self._white_balance_supported_modes[parameter_path] = modes
+                return self._white_balance_supported_modes[parameter_path], ''
 
         # Fallback if XML definitions are unavailable
-        self._white_balance_supported_modes = set(['auto', 'fixed_indoor', 'fixed_outdoor', 'hold'])
-        return self._white_balance_supported_modes, ''
+        self._white_balance_supported_modes[parameter_path] = set(['auto', 'fixed_indoor', 'fixed_outdoor', 'hold'])
+        return self._white_balance_supported_modes[parameter_path], ''
 
     def _get_supported_day_night_modes(self, parameter_path):
-        if self._day_night_supported_modes is not None:
-            return self._day_night_supported_modes, ''
+        if parameter_path in self._day_night_supported_modes:
+            return self._day_night_supported_modes[parameter_path], ''
 
         parts = parameter_path.rsplit('.', 1)
         if len(parts) == 2:
             group, parameter_name = parts
             modes = self._get_parameter_enum_values_from_definitions(group, parameter_name)
             if modes:
-                self._day_night_supported_modes = modes
-                return self._day_night_supported_modes, ''
+                self._day_night_supported_modes[parameter_path] = modes
+                return self._day_night_supported_modes[parameter_path], ''
 
         # Fallback if XML definitions are unavailable
         if 'DayNightShift' in parameter_path:
-            self._day_night_supported_modes = set(['auto', 'day', 'night'])
+            self._day_night_supported_modes[parameter_path] = set(['auto', 'day', 'night'])
         else:  # IrCutFilter
-            self._day_night_supported_modes = set(['auto', 'yes', 'no'])
-        return self._day_night_supported_modes, ''
+            self._day_night_supported_modes[parameter_path] = set(['auto', 'yes', 'no'])
+        return self._day_night_supported_modes[parameter_path], ''
 
     def _supports_day_night_mode(self):
         try:
@@ -463,6 +515,39 @@ class ControlAxis():
                 return value == 'yes', ''
 
         return True, ''
+
+    def _update_via_param_cgi(self, parameter_path, value, success_label):
+        """Update a parameter using /axis-cgi/param.cgi with the root. prefix (VAPIX v2 style)."""
+        ret = {
+            'success': False,
+            'message': ''
+        }
+
+        params = urllib_parse.urlencode({
+            'action': 'update',
+            'root.' + parameter_path: value
+        })
+        url = 'http://%s/axis-cgi/param.cgi?%s' % (self.hostname, params)
+
+        try:
+            opener = self._get_digest_opener()
+            response = opener.open(url, timeout=5)
+            body = response.read().decode('utf-8').strip()
+
+            if body == 'OK':
+                ret['success'] = True
+                ret['message'] = '%s set to %s' % (success_label, value)
+            else:
+                ret['message'] = 'camera rejected update (param.cgi): %s' % body
+
+        except urllib_error.HTTPError as e:
+            ret['message'] = 'HTTP error %d: %s' % (e.code, e.reason)
+        except urllib_error.URLError as e:
+            ret['message'] = 'connection error: %s' % e.reason
+        except socket.timeout:
+            ret['message'] = 'connection timeout'
+
+        return ret
 
     def _update_parameter_path(self, parameter_path, value, success_label):
         ret = {
@@ -843,6 +928,9 @@ class ControlAxis():
             }
 
         result = self._update_parameter_path(parameter_path, white_balance, 'white_balance')
+        if not result['success']:
+            # Fall back to /axis-cgi/param.cgi with root. prefix (VAPIX v2 style)
+            result = self._update_via_param_cgi(parameter_path, white_balance, 'white_balance')
         if result['success']:
             self._last_known_image_settings['white_balance'] = white_balance
         return result
@@ -856,14 +944,14 @@ class ControlAxis():
                 'success': False,
                 'message': error_message
             }
-        if not supports_day_night:
-            return {
-                'success': False,
-                'message': 'camera does not support manual day/night mode control'
-            }
 
         parameter_path, error_message = self._get_day_night_parameter_path()
         if parameter_path is None:
+            if not supports_day_night:
+                return {
+                    'success': False,
+                    'message': 'camera does not support manual day/night mode control'
+                }
             return {
                 'success': False,
                 'message': error_message
@@ -894,6 +982,9 @@ class ControlAxis():
             }
 
         result = self._update_parameter_path(parameter_path, vapix_mode, 'day_night_mode')
+        if not result['success']:
+            # Fall back to /axis-cgi/param.cgi with root. prefix (VAPIX v2 style)
+            result = self._update_via_param_cgi(parameter_path, vapix_mode, 'day_night_mode')
         if result['success']:
             if 'DayNightShift' in parameter_path:
                 if vapix_mode == 'night':
@@ -908,6 +999,7 @@ class ControlAxis():
         return result
 
     def setDayNightShiftLevel(self, shift_level):
+        parameter_path = 'ImageSource.I0.DayNight.ShiftLevel'
         shift_range = self._get_parameter_int_range_from_definitions('ImageSource.I0.DayNight', 'ShiftLevel')
         if shift_range[0] is not None:
             min_shift, max_shift = shift_range
@@ -920,7 +1012,18 @@ class ControlAxis():
                 'message': 'shift_level value %d is out of range [%d, %d]' % (shift_level, min_shift, max_shift)
             }
 
-        result = self._update_parameter_path_verified('ImageSource.I0.DayNight.ShiftLevel', shift_level, 'day_night_shift_level')
+        previous_value = self._read_parameter_value(parameter_path)
+        result = self._update_parameter_path(parameter_path, shift_level, 'day_night_shift_level')
+        if not result['success']:
+            # Fall back to /axis-cgi/param.cgi with root. prefix (VAPIX v2 style)
+            result = self._update_via_param_cgi(parameter_path, shift_level, 'day_night_shift_level')
+        result = self._verify_and_rollback_parameter_update(
+            parameter_path,
+            shift_level,
+            previous_value,
+            result,
+            'day_night_shift_level'
+        )
         if result['success']:
             self._last_known_image_settings['day_night_shift_level'] = shift_level
         return result

--- a/src/axis_camera/axis_lib/axis_control.py
+++ b/src/axis_camera/axis_lib/axis_control.py
@@ -853,6 +853,52 @@ class ControlAxis():
 
         return result
 
+    def setDCIrisPosition(self, iris_percentage):
+        if iris_percentage < 0.0 or iris_percentage > 100.0:
+            return {
+                'success': False,
+                'message': 'iris percentage %.1f is out of range [0, 100]' % iris_percentage
+            }
+
+        # Manual position is ignored on some cameras while DCIris auto mode is enabled.
+        disable_auto_result = self.setDCIrisEnabled(False)
+        if not disable_auto_result.get('success', False):
+            return {
+                'success': False,
+                'message': 'failed to disable DCIris auto mode: %s' % disable_auto_result.get('message', 'unknown error')
+            }
+
+        parameter_path = 'ImageSource.I0.DCIris.Position'
+        dciris_position = int(round(iris_percentage))
+        previous_value = self._read_parameter_value(parameter_path)
+        result = self._update_via_param_cgi(parameter_path, dciris_position, 'iris')
+        return self._verify_and_rollback_parameter_update(
+            parameter_path,
+            dciris_position,
+            previous_value,
+            result,
+            'iris'
+        )
+
+    def setDCIrisEnabled(self, enabled):
+        parameter_path = 'ImageSource.I0.DCIris.Enabled'
+        enabled_value = 'yes' if enabled else 'no'
+        previous_value = self._read_parameter_value(parameter_path)
+        result = self._update_via_param_cgi(parameter_path, enabled_value, 'autoiris')
+        return self._verify_and_rollback_parameter_update(
+            parameter_path,
+            enabled_value,
+            previous_value,
+            result,
+            'autoiris'
+        )
+
+    def getDCIrisEnabledState(self):
+        enabled_value = self._read_parameter_value('ImageSource.I0.DCIris.Enabled')
+        if enabled_value is None:
+            return None
+        return enabled_value.strip().lower() == 'yes'
+
     def getWhiteBalanceModes(self):
         parameter_path, error_message = self._get_white_balance_parameter_path()
         if parameter_path is None:

--- a/src/axis_camera/axis_ptz_node.py
+++ b/src/axis_camera/axis_ptz_node.py
@@ -213,6 +213,23 @@ class AxisPTZ(threading.Thread):
     def _irisPercentageToRaw(self, iris_percentage):
         clamped_percentage = min(max(iris_percentage, 0.0), 100.0)
         return self.iris_min_value + ((self.iris_max_value - self.iris_min_value) * (clamped_percentage / 100.0))
+
+    def _shouldTryDCIrisFallback(self, requested_iris_percent):
+        ptz_read = self.controller.getPTZState()
+        if ptz_read.get("error_reading", True):
+            return False
+
+        if ptz_read.get("autoiris", False):
+            return True
+
+        actual_iris_percent = self._irisRawToPercentage(ptz_read.get("iris", self.iris_min_value))
+        return abs(actual_iris_percent - requested_iris_percent) > 5.0
+
+    def _shouldTryDCIrisAutoFallback(self):
+        dciris_enabled = self.controller.getDCIrisEnabledState()
+        if dciris_enabled is not None:
+            return not dciris_enabled
+        return True
     
     def _updateEffectiveFocusFromCommand(self, commanded_focus_percent, actual_focus_percent, autofocus_enabled):
         """
@@ -608,16 +625,62 @@ class AxisPTZ(threading.Thread):
             self.controller.sendPTZCommand(autoiris=False)
         control = self.controller.sendPTZCommand(iris=iris_value, autoiris=req.auto)
         if not self._commandSucceeded(control, 'iris'):
+            if req.auto:
+                fallback_result = self.controller.setDCIrisEnabled(True)
+                if fallback_result.get('success', False):
+                    self.desired_autoiris = True
+                    response.ret = True
+                    response.message = 'Autoiris enabled through DCIris fallback'
+                    return response
+
+            if not req.auto:
+                fallback_result = self.controller.setDCIrisPosition(req.value)
+                if fallback_result.get('success', False):
+                    self.desired_autoiris = False
+                    self.desired_iris = req.value
+                    response.ret = True
+                    response.message = 'Iris command sent through DCIris fallback'
+                    return response
+
             response.ret = False
-            response.message = self._formatCommandError(control, 'iris')
+            if not req.auto:
+                response.message = 'PTZ iris failed (%s); DCIris fallback failed (%s)' % (
+                    self._formatCommandError(control, 'iris'),
+                    fallback_result.get('message', 'unknown error')
+                )
+            else:
+                response.message = 'PTZ autoiris failed (%s); DCIris fallback failed (%s)' % (
+                    self._formatCommandError(control, 'iris'),
+                    fallback_result.get('message', 'unknown error')
+                )
             return response
+
+        if not req.auto and self._shouldTryDCIrisFallback(req.value):
+            fallback_result = self.controller.setDCIrisPosition(req.value)
+            if fallback_result.get('success', False):
+                self.desired_autoiris = False
+                self.desired_iris = req.value
+                response.ret = True
+                response.message = 'Iris command sent through DCIris fallback after PTZ readback mismatch'
+                return response
+
+        if req.auto and self._shouldTryDCIrisAutoFallback():
+            fallback_result = self.controller.setDCIrisEnabled(True)
+            if fallback_result.get('success', False):
+                self.desired_autoiris = True
+                response.ret = True
+                response.message = 'Autoiris enabled through DCIris fallback after PTZ readback mismatch'
+                return response
 
         self.desired_autoiris = req.auto
         if iris_value is not None:
             self.desired_iris = req.value  # store as percentage
 
         response.ret = True
-        response.message = 'Iris command sent'
+        if req.auto:
+            response.message = 'Autoiris command sent through PTZ'
+        else:
+            response.message = 'Iris command sent'
         return response
 
     def _commandSucceeded(self, control, feature_name):

--- a/src/axis_camera/axis_ptz_node.py
+++ b/src/axis_camera/axis_ptz_node.py
@@ -298,6 +298,7 @@ class AxisPTZ(threading.Thread):
         self.set_day_night_shift_level_service = rospy.Service('~set_day_night_shift_level', SetInt16, self.setDayNightShiftLevelServiceCb)
         self.set_white_balance_service = rospy.Service('~set_white_balance', SetString, self.setWhiteBalanceServiceCb)
         self.get_white_balance_mode_service = rospy.Service('~get_white_balance_mode', GetStringList, self.getWhiteBalanceModeServiceCb)
+        self.get_day_night_mode_service = rospy.Service('~get_day_night_mode', GetStringList, self.getDayNightModeServiceCb)
         self.get_image_settings_service = rospy.Service('~get_image_settings', GetImageSettings, self.getImageSettingsServiceCb)
         self.loadDeviceInfo()
         self.device_info_service = rospy.Service('~get_device_info', GetAxisDeviceInfo, self.getDeviceInfoServiceCb)
@@ -494,6 +495,17 @@ class AxisPTZ(threading.Thread):
             rospy.loginfo('%s:getWhiteBalanceModeServiceCb: %s', rospy.get_name(), result['message'])
         else:
             rospy.logerr('%s:getWhiteBalanceModeServiceCb: %s', rospy.get_name(), result['message'])
+        return GetStringListResponse(
+            strings=result['modes'],
+            ret=ReturnMessage(success=result['success'], message=result['message'])
+        )
+
+    def getDayNightModeServiceCb(self, req):
+        result = self.controller.getDayNightModes()
+        if result['success']:
+            rospy.loginfo('%s:getDayNightModeServiceCb: %s', rospy.get_name(), result['message'])
+        else:
+            rospy.logerr('%s:getDayNightModeServiceCb: %s', rospy.get_name(), result['message'])
         return GetStringListResponse(
             strings=result['modes'],
             ret=ReturnMessage(success=result['success'], message=result['message'])


### PR DESCRIPTION
### Summary
 This PR adds fallback support for cameras where the primary PTZ CGI endpoint does not accept iris, white balance or day/night commands. It also includes a service that displays the camera's available day and night modes. 

 **Changes:**
- **White balance** and **day/night** (axis_control.py): adds a secondary lookup path via `/axis-cgi/param.cgi` (with `root.*` prefix) when `admin/param.cgi` returns an error or empty response. Also prefers `IrCutFilter` over `DayNightShift` when available, avoiding false "unsupported" rejections.
- **Iris control** (axis_control.py, axis_ptz_node.py): adds `setDCIrisPosition` / `setDCIrisEnabled` via `ImageSource.I0.DCIris.*` as a fallback when the PTZ iris command fails or the readback does not match. The PTZ path is always tried first.

> **Known limitation:** On some camera models (e.g. P5676-LE), the `iris` field in `camera_params` is always reported as ~50% regardless of the commanded value, because the firmware does not expose the actual iris position via the PTZ CGI readback. The iris does change physically on the camera; it is purely a readback limitation.

### getDayNightModes
**Changes:**
- **axis_control.py:** added getDayNightModes() and normalization logic.
- **axis_ptz_node.py**: registered ~get_day_night_mode service and added getDayNightModeServiceCb handler.

Behavior: getDayNightModes() queries firmware definitions when available; it always returns (where supported) a deterministic list starting with auto, day, night. Any unusual firmware modes are included only after normalization.

```
rosservice call /axis_camera_ptz/get_day_night_mode "data: ''" 
```